### PR TITLE
Fix typos

### DIFF
--- a/notifiers/utils/json_schema.py
+++ b/notifiers/utils/json_schema.py
@@ -1,7 +1,7 @@
 def one_or_more(schema: dict, unique_items: bool = True) -> dict:
     """
-    Helper function to construct a schema that validates items matching `schema` or an array
-     containing items matching `schema`.
+    Helper function to construct a schema that validates items matching
+    `schema` or an array containing items matching `schema`.
 
     :param schema: The schema to use
     :param unique_items: Flag if array items should be unique
@@ -21,10 +21,11 @@ def one_or_more(schema: dict, unique_items: bool = True) -> dict:
 
 def list_to_commas(list_: list) -> str:
     """
-    Converts a list of items to a coma separated list. If `list_` is not a list, just return it back
+    Converts a list of items to a comma separated list. If `list_` is
+    not a list, just return it back
 
     :param list_: List of items
-    :return: A string representing a coma separated list.
+    :return: A string representing a comma separated list.
     """
     if isinstance(list_, list):
         return ",".join(list_)

--- a/tests/providers/test_gmail.py
+++ b/tests/providers/test_gmail.py
@@ -4,7 +4,7 @@ from notifiers import get_notifier
 from notifiers.exceptions import BadArguments, NotificationError
 
 
-class TestGmmail(object):
+class TestGmail(object):
     """Gmail tests"""
 
     def test_gmail_metadata(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -205,7 +205,7 @@ class TestJoinCLI:
 
 
 class TestHipchatCLI:
-    """Test hipchat speicifc CLI"""
+    """Test hipchat specific CLI"""
 
     def test_hipchat_rooms_negative(self):
         from notifiers_cli.providers.hipchat import rooms


### PR DESCRIPTION
old | new
:---: | :---:
  `coma` | `comma`
  `Gmmail` | `Gmail`
  `speicifc` | `specific`

I also shortened two docstring lines so they weren't longer than 72 characters.

> [For flowing long blocks of text with fewer structural restrictions (docstrings or comments), the line length should be limited to 72 characters.](http://pep8.org/#maximum-line-length)
