### PR TITLE
Seperated `required` part of all schemas

### DIFF
--- a/notifiers/core.py
+++ b/notifiers/core.py
@@ -49,6 +49,9 @@ class Provider:
     site_url = ''
     provider_name = ''
 
+    _required = {}
+    _schema = {}
+
     def __repr__(self):
         return f'<Provider:[{self.provider_name.capitalize()}]>'
 
@@ -60,7 +63,10 @@ class Provider:
 
         :return: JSON schema of the provider
         """
-        raise NotImplementedError
+        if not self._required or not self._schema:
+            raise NotImplementedError
+        self._schema.update(self._required)
+        return self._schema
 
     @property
     def metadata(self) -> dict:
@@ -81,13 +87,11 @@ class Provider:
         return dict(self.schema['properties'].items())
 
     @property
-    def required(self) -> list:
+    def required(self) -> dict:
         """
-        Return a list of the required provider arguments. By default, it tries to access the ``required``
-         property of the JSON schema. If such a property doesn't exist (perhaps required is enforced via a
-          sophisticated schema form), override this method to return the correct list of required arguments.
+        Returns a dict of the relevant required parts of the schema
         """
-        return self.schema.get('required', [])
+        return self._required
 
     @property
     def defaults(self) -> dict:

--- a/notifiers/providers/email.py
+++ b/notifiers/providers/email.py
@@ -20,73 +20,74 @@ class SMTP(Provider):
     site_url = 'https://en.wikipedia.org/wiki/Email'
     provider_name = 'email'
 
+    _required = {
+        'required': ['message', 'to'],
+        'dependencies': {
+            'username': ['password'],
+            'password': ['username'],
+            'ssl': ['tls']
+        }
+    }
+
+    _schema = {
+        'type': 'object',
+        'properties': {
+            'message': {
+                'type': 'string',
+                'title': 'the content of the email message'
+            },
+            'subject': {
+                'type': 'string',
+                'title': 'the subject of the email message'
+            },
+            'to': one_or_more({
+                'type': 'string',
+                'format': 'email',
+                'title': 'one or more email addresses to use'
+            }),
+            'from': {
+                'type': 'string',
+                'title': 'the FROM address to use in the email'
+            },
+            'from_': {
+                'type': 'string',
+                'title': 'the FROM address to use in the email'
+            },
+            'host': {
+                'type': 'string',
+                'title': 'the host of the SMTP server'
+            },
+            'port': {
+                'type': 'integer',
+                'title': 'the port number to use'
+            },
+            'username': {
+                'type': 'string',
+                'title': 'username if relevant'
+            },
+            'password': {
+                'type': 'string',
+                'title': 'password if relevant'
+            },
+            'tls': {
+                'type': 'boolean',
+                'title': 'should TLS be used'
+            },
+            'ssl': {
+                'type': 'boolean',
+                'title': 'should SSL be used'
+            },
+            'html': {
+                'type': 'boolean',
+                'title': 'should the email be parse as an HTML file'
+            }
+        },
+        'additionalProperties': False,
+    }
+
     def __init__(self):
         self.smtp_server = None
         self.configuration = None
-
-    @property
-    def schema(self) -> dict:
-        return {
-            'type': 'object',
-            'properties': {
-                'message': {
-                    'type': 'string',
-                    'title': 'the content of the email message'
-                },
-                'subject': {
-                    'type': 'string',
-                    'title': 'the subject of the email message'
-                },
-                'to': one_or_more({
-                    'type': 'string',
-                    'format': 'email',
-                    'title': 'one or more email addresses to use'
-                }),
-                'from': {
-                    'type': 'string',
-                    'title': 'the FROM address to use in the email'
-                },
-                'from_': {
-                    'type': 'string',
-                    'title': 'the FROM address to use in the email'
-                },
-                'host': {
-                    'type': 'string',
-                    'title': 'the host of the SMTP server'
-                },
-                'port': {
-                    'type': 'integer',
-                    'title': 'the port number to use'
-                },
-                'username': {
-                    'type': 'string',
-                    'title': 'username if relevant'
-                },
-                'password': {
-                    'type': 'string',
-                    'title': 'password if relevant'
-                },
-                'tls': {
-                    'type': 'boolean',
-                    'title': 'should TLS be used'
-                },
-                'ssl': {
-                    'type': 'boolean',
-                    'title': 'should SSL be used'
-                },
-                'html': {
-                    'type': 'boolean',
-                    'title': 'should the email be parse as an HTML file'
-                }
-            },
-            'required': ['message', 'to'],
-            'dependencies': {
-                'username': ['password'],
-                'password': ['username'],
-                'ssl': ['tls']
-            },
-            'additionalProperties': False,
-        }
 
     @property
     def defaults(self) -> dict:

--- a/notifiers/providers/gitter.py
+++ b/notifiers/providers/gitter.py
@@ -11,27 +11,26 @@ class Gitter(Provider):
     site_url = 'https://gitter.im'
     provider_name = 'gitter'
 
-    @property
-    def schema(self) -> dict:
-        return {
-            'type': 'object',
-            'properties': {
-                'message': {
-                    'type': 'string',
-                    'title': 'Body of the message'
-                },
-                'token': {
-                    'type': 'string',
-                    'title': 'access token'
-                },
-                'room_id': {
-                    'type': 'string',
-                    'title': 'ID of the room to send the notification to'
-                }
+    _required = {'required': ['message', 'token', 'room_id']}
+    _schema = {
+        'type': 'object',
+        'properties': {
+            'message': {
+                'type': 'string',
+                'title': 'Body of the message'
             },
-            'required': ['message', 'token', 'room_id'],
-            'additionalProperties': False
-        }
+            'token': {
+                'type': 'string',
+                'title': 'access token'
+            },
+            'room_id': {
+                'type': 'string',
+                'title': 'ID of the room to send the notification to'
+            }
+        },
+        'required': ['message', 'token', 'room_id'],
+        'additionalProperties': False
+    }
 
     def _prepare_data(self, data: dict) -> dict:
         data['text'] = data.pop('message')

--- a/notifiers/providers/hipchat.py
+++ b/notifiers/providers/hipchat.py
@@ -14,7 +14,7 @@ class HipChat(Provider):
     site_url = 'https://www.hipchat.com/docs/apiv2'
     provider_name = 'hipchat'
 
-    __icon = {
+    _icon = {
         'oneOf': [
             {
                 'type': 'string'
@@ -37,7 +37,7 @@ class HipChat(Provider):
         ]
     }
 
-    __value = {
+    _value = {
         'type': 'object',
         'properties': {
             'url': {
@@ -56,17 +56,17 @@ class HipChat(Provider):
                 'type': 'string',
                 'title': 'The text representation of the value'
             },
-            'icon': __icon
+            'icon': _icon
         }
     }
 
-    __attributes = {
+    _attributes = {
         'type': 'array',
         'title': 'List of attributes to show below the card',
         'items': {
             'type': 'object',
             'properties': {
-                'value': __value,
+                'value': _value,
                 'label': {
                     'type': 'string',
                     'title': 'Attribute label',
@@ -79,20 +79,20 @@ class HipChat(Provider):
         }
     }
 
-    __activity = {
+    _activity = {
         'type': 'object',
         'properties': {
             'html': {
                 'type': 'string',
                 'title': 'Html for the activity to show in one line a summary of the action that happened'
             },
-            'icon': __icon,
+            'icon': _icon,
         },
         'required': ['html'],
         'additionalProperties': False
     }
 
-    __thumbnail = {
+    _thumbnail = {
         'type': 'object',
         'properties': {
             'url': {
@@ -120,7 +120,7 @@ class HipChat(Provider):
         'additionalProperties': False
     }
 
-    __format = {
+    _format = {
         'type': 'string',
         'enum': [
             'text', 'html'
@@ -129,7 +129,7 @@ class HipChat(Provider):
                  'applications'
     }
 
-    __description = {
+    _description = {
         'oneOf': [
             {
                 'type': 'string'
@@ -142,7 +142,7 @@ class HipChat(Provider):
                         'minLength': 1,
                         'maxLength': 1000
                     },
-                    'format': __format
+                    'format': _format
                 },
                 'required': ['value', 'format'],
                 'additionalProperties': False
@@ -150,7 +150,7 @@ class HipChat(Provider):
         ]
     }
 
-    __card = {
+    _card = {
         'type': 'object',
         'properties': {
             'style': {
@@ -160,7 +160,7 @@ class HipChat(Provider):
                 ],
                 'title': 'Type of the card'
             },
-            'description': __description,
+            'description': _description,
             'format': {
                 'type': 'string',
                 'enum': [
@@ -178,15 +178,15 @@ class HipChat(Provider):
                 'maxLength': 500,
                 'title': 'The title of the card'
             },
-            'thumbnail': __thumbnail,
-            'activity': __activity,
-            'attributes': __attributes,
+            'thumbnail': _thumbnail,
+            'activity': _activity,
+            'attributes': _attributes,
         },
         'required': ['style', 'title'],
         'additionalProperties': False
     }
 
-    __required = {
+    _required = {
         'allOf': [
             {'required': ['message', 'id', 'token']},
             {'oneOf': [
@@ -199,85 +199,76 @@ class HipChat(Provider):
             ]}
         ]
     }
-
-    @property
-    def schema(self) -> dict:
-        schema = {
-            'type': 'object',
-            'properties': {
-                'room': {
-                    'type': 'string',
-                    'title': 'The id or url encoded name of the room',
-                    'maxLength': 100,
-                    'minLength': 1
-                },
-                'user': {
-                    'type': 'string',
-                    'title': "The id, email address, or mention name (beginning with an '@') "
-                             "of the user to send a message to."
-                },
-                'message': {
-                    'type': 'string',
-                    'title': 'The message body',
-                    'maxLength': 10_000,
-                    'minLength': 1
-                },
-                'token': {
-                    'type': 'string',
-                    'title': 'User token'
-                },
-                'notify': {
-                    'type': 'boolean',
-                    'title': "Whether this message should trigger a user notification (change the tab color,"
-                             " play a sound, notify mobile phones, etc). Each recipient's notification preferences "
-                             "are taken into account."
-                },
-                'message_format': {
-                    'type': 'string',
-                    'enum': [
-                        'text', 'html'
-                    ],
-                    'title': 'Determines how the message is treated by our server and rendered inside HipChat '
-                             'applications'
-                },
-                'from': {
-                    'type': 'string',
-                    'title': "A label to be shown in addition to the sender's name"
-                },
-                'color': {
-                    'type': 'string',
-                    'enum': [
-                        'yellow', 'green', 'red', 'purple', 'gray', 'random'
-                    ],
-                    'title': 'Background color for message'
-                },
-                'attach_to': {
-                    'type': 'string',
-                    'title': 'The message id to to attach this notification to'
-                },
-                'card': self.__card,
-                'id': {
-                    'type': 'string',
-                    'title': 'An id that will help HipChat recognise the same card when it is sent multiple times'
-                },
-                'icon': self.__icon,
-                'team_server': {
-                    'type': 'string',
-                    'title': "An alternate team server. Example: 'https://hipchat.corp-domain.com'"
-                },
-                'group': {
-                    'type': 'string',
-                    'title': 'HipChat group name'
-                }
+    _schema = {
+        'type': 'object',
+        'properties': {
+            'room': {
+                'type': 'string',
+                'title': 'The id or url encoded name of the room',
+                'maxLength': 100,
+                'minLength': 1
             },
-            'additionalProperties': False
-        }
-        schema.update(self.__required)
-        return schema
-
-    @property
-    def required(self) -> dict:
-        return self.__required
+            'user': {
+                'type': 'string',
+                'title': "The id, email address, or mention name (beginning with an '@') "
+                         "of the user to send a message to."
+            },
+            'message': {
+                'type': 'string',
+                'title': 'The message body',
+                'maxLength': 10_000,
+                'minLength': 1
+            },
+            'token': {
+                'type': 'string',
+                'title': 'User token'
+            },
+            'notify': {
+                'type': 'boolean',
+                'title': "Whether this message should trigger a user notification (change the tab color,"
+                         " play a sound, notify mobile phones, etc). Each recipient's notification preferences "
+                         "are taken into account."
+            },
+            'message_format': {
+                'type': 'string',
+                'enum': [
+                    'text', 'html'
+                ],
+                'title': 'Determines how the message is treated by our server and rendered inside HipChat '
+                         'applications'
+            },
+            'from': {
+                'type': 'string',
+                'title': "A label to be shown in addition to the sender's name"
+            },
+            'color': {
+                'type': 'string',
+                'enum': [
+                    'yellow', 'green', 'red', 'purple', 'gray', 'random'
+                ],
+                'title': 'Background color for message'
+            },
+            'attach_to': {
+                'type': 'string',
+                'title': 'The message id to to attach this notification to'
+            },
+            'card': _card,
+            'id': {
+                'type': 'string',
+                'title': 'An id that will help HipChat recognise the same card when it is sent multiple times'
+            },
+            'icon': _icon,
+            'team_server': {
+                'type': 'string',
+                'title': "An alternate team server. Example: 'https://hipchat.corp-domain.com'"
+            },
+            'group': {
+                'type': 'string',
+                'title': 'HipChat group name'
+            }
+        },
+        'additionalProperties': False
+    }
 
     def _prepare_data(self, data: dict) -> dict:
         base_url = self.base_url.format(group=data.pop('group')) if not data.get('team_server') else data.pop(

--- a/notifiers/providers/hipchat.py
+++ b/notifiers/providers/hipchat.py
@@ -14,7 +14,7 @@ class HipChat(Provider):
     site_url = 'https://www.hipchat.com/docs/apiv2'
     provider_name = 'hipchat'
 
-    _icon = {
+    __icon = {
         'oneOf': [
             {
                 'type': 'string'
@@ -37,7 +37,7 @@ class HipChat(Provider):
         ]
     }
 
-    _value = {
+    __value = {
         'type': 'object',
         'properties': {
             'url': {
@@ -56,17 +56,17 @@ class HipChat(Provider):
                 'type': 'string',
                 'title': 'The text representation of the value'
             },
-            'icon': _icon
+            'icon': __icon
         }
     }
 
-    _attributes = {
+    __attributes = {
         'type': 'array',
         'title': 'List of attributes to show below the card',
         'items': {
             'type': 'object',
             'properties': {
-                'value': _value,
+                'value': __value,
                 'label': {
                     'type': 'string',
                     'title': 'Attribute label',
@@ -79,20 +79,20 @@ class HipChat(Provider):
         }
     }
 
-    _activity = {
+    __activity = {
         'type': 'object',
         'properties': {
             'html': {
                 'type': 'string',
                 'title': 'Html for the activity to show in one line a summary of the action that happened'
             },
-            'icon': _icon,
+            'icon': __icon,
         },
         'required': ['html'],
         'additionalProperties': False
     }
 
-    _thumbnail = {
+    __thumbnail = {
         'type': 'object',
         'properties': {
             'url': {
@@ -120,7 +120,7 @@ class HipChat(Provider):
         'additionalProperties': False
     }
 
-    _format = {
+    __format = {
         'type': 'string',
         'enum': [
             'text', 'html'
@@ -129,7 +129,7 @@ class HipChat(Provider):
                  'applications'
     }
 
-    _description = {
+    __description = {
         'oneOf': [
             {
                 'type': 'string'
@@ -142,7 +142,7 @@ class HipChat(Provider):
                         'minLength': 1,
                         'maxLength': 1000
                     },
-                    'format': _format
+                    'format': __format
                 },
                 'required': ['value', 'format'],
                 'additionalProperties': False
@@ -150,7 +150,7 @@ class HipChat(Provider):
         ]
     }
 
-    _card = {
+    __card = {
         'type': 'object',
         'properties': {
             'style': {
@@ -160,7 +160,7 @@ class HipChat(Provider):
                 ],
                 'title': 'Type of the card'
             },
-            'description': _description,
+            'description': __description,
             'format': {
                 'type': 'string',
                 'enum': [
@@ -178,9 +178,9 @@ class HipChat(Provider):
                 'maxLength': 500,
                 'title': 'The title of the card'
             },
-            'thumbnail': _thumbnail,
-            'activity': _activity,
-            'attributes': _attributes,
+            'thumbnail': __thumbnail,
+            'activity': __activity,
+            'attributes': __attributes,
         },
         'required': ['style', 'title'],
         'additionalProperties': False
@@ -252,12 +252,12 @@ class HipChat(Provider):
                 'type': 'string',
                 'title': 'The message id to to attach this notification to'
             },
-            'card': _card,
+            'card': __card,
             'id': {
                 'type': 'string',
                 'title': 'An id that will help HipChat recognise the same card when it is sent multiple times'
             },
-            'icon': _icon,
+            'icon': __icon,
             'team_server': {
                 'type': 'string',
                 'title': "An alternate team server. Example: 'https://hipchat.corp-domain.com'"

--- a/notifiers/providers/join.py
+++ b/notifiers/providers/join.py
@@ -12,135 +12,136 @@ class Join(Provider):
     site_url = 'https://joaoapps.com/join/api/'
     provider_name = 'join'
 
-    @property
-    def schema(self) -> dict:
-        return {
-            'type': 'object',
-            'properties': {
-                'message': {
-                    'type': 'string',
-                    'title': 'usually used as a Tasker or EventGhost command. Can also be used with URLs and Files '
-                             'to add a description for those elements'
-                },
-                'apikey': {
-                    'type': 'string',
-                    'title': 'user API key'
-                },
-                'deviceId': {
-                    'type': 'string',
-                    'title': 'The device ID or group ID of the device you want to send the message to'
-                },
-                'deviceIds': one_or_more({
-                    'type': 'string',
-                    'title': 'A comma separated list of device IDs you want to send the push to'
-                }),
-                'deviceNames': one_or_more({
-                    'type': 'string',
-                    'title': 'A comma separated list of device names you want to send the push to'
-                }),
-                'url': {
-                    'type': 'string',
-                    'title': ' A URL you want to open on the device. If a notification is created with this push, '
-                             'this will make clicking the notification open this URL'
-                },
-                'clipboard': {
-                    'type': 'string',
-                    'title': 'some text you want to set on the receiving device’s clipboard'
-                },
-                'file': {
-                    'type': 'string',
-                    'title': 'a publicly accessible URL of a file'
-                },
-                'smsnumber': {
-                    'type': 'string',
-                    'title': 'phone number to send an SMS to'
-                },
-                'smstext': {
-                    'type': 'string',
-                    'title': 'some text to send in an SMS'
-                },
-                'callnumber': {
-                    'type': 'string',
-                    'title': 'number to call to'
-                },
-                'interruptionFilter': {
-                    'type': 'integer',
-                    'minimum': 1,
-                    'maximum': 4,
-                    'title': 'set interruption filter mode'
-                },
-                'mmsfile': {
-                    'type': 'string',
-                    'title': 'publicly accessible mms file url'
-                },
-                'mediaVolume': {
-                    'type': 'integer',
-                    'title': 'set device media volume'
-                },
-                'ringVolume': {
-                    'type': 'string',
-                    'title': 'set device ring volume'
-                },
-                'alarmVolume': {
-                    'type': 'string',
-                    'title': 'set device alarm volume'
-                },
-                'wallpaper': {
-                    'type': 'string',
-                    'title': 'a publicly accessible URL of an image file'
-                },
-                'find': {
-                    'type': 'boolean',
-                    'title': 'set to true to make your device ring loudly'
-                },
-                'title': {
-                    'type': 'string',
-                    'title': 'If used, will always create a notification on the receiving device with this as the '
-                             'title and text as the notification’s text'
-                },
-                'icon': {
-                    'type': 'string',
-                    'title': "notification's icon"
-                },
-                'smallicon': {
-                    'type': 'string',
-                    'title': 'Status Bar Icon'
-                },
-                'priority': {
-                    'type': 'integer',
-                    'title': 'control how your notification is displayed',
-                    'minimum': -2,
-                    'maximum': 2
-                },
-                'group': {
-                    'type': 'string',
-                    'title': 'allows you to join notifications in different groups'
-                },
-                'image': {
-                    'type': 'string',
-                    'title': 'Notification image'
+    _required = {
+        'dependencies': {
+            'smstext': ['smsnumber'],
+            'callnumber': ['smsnumber']
+        },
+        'anyOf': [
+            {
+                'dependencies': {
+                    'smsnumber': ['smstext']
                 }
             },
-            'dependencies': {
-                'smstext': ['smsnumber'],
-                'callnumber': ['smsnumber']
-            },
-            'anyOf': [
-                {
-                    'dependencies': {
-                        'smsnumber': ['smstext']
-                    }
-                },
-                {
-                    'dependencies':{
-                        'smsnumber': ['mmsfile']
-                    }
+            {
+                'dependencies': {
+                    'smsnumber': ['mmsfile']
                 }
-            ],
-            'error_anyOf': "Must use either 'smstext' or 'mmsfile' with 'smsnumber'",
-            'required': ['apikey', 'message'],
-            'additionalProperties': False
-        }
+            }
+        ],
+        'error_anyOf': "Must use either 'smstext' or 'mmsfile' with 'smsnumber'",
+        'required': ['apikey', 'message']
+    }
+
+    _schema = {
+        'type': 'object',
+        'properties': {
+            'message': {
+                'type': 'string',
+                'title': 'usually used as a Tasker or EventGhost command. Can also be used with URLs and Files '
+                         'to add a description for those elements'
+            },
+            'apikey': {
+                'type': 'string',
+                'title': 'user API key'
+            },
+            'deviceId': {
+                'type': 'string',
+                'title': 'The device ID or group ID of the device you want to send the message to'
+            },
+            'deviceIds': one_or_more({
+                'type': 'string',
+                'title': 'A comma separated list of device IDs you want to send the push to'
+            }),
+            'deviceNames': one_or_more({
+                'type': 'string',
+                'title': 'A comma separated list of device names you want to send the push to'
+            }),
+            'url': {
+                'type': 'string',
+                'title': ' A URL you want to open on the device. If a notification is created with this push, '
+                         'this will make clicking the notification open this URL'
+            },
+            'clipboard': {
+                'type': 'string',
+                'title': 'some text you want to set on the receiving device’s clipboard'
+            },
+            'file': {
+                'type': 'string',
+                'title': 'a publicly accessible URL of a file'
+            },
+            'smsnumber': {
+                'type': 'string',
+                'title': 'phone number to send an SMS to'
+            },
+            'smstext': {
+                'type': 'string',
+                'title': 'some text to send in an SMS'
+            },
+            'callnumber': {
+                'type': 'string',
+                'title': 'number to call to'
+            },
+            'interruptionFilter': {
+                'type': 'integer',
+                'minimum': 1,
+                'maximum': 4,
+                'title': 'set interruption filter mode'
+            },
+            'mmsfile': {
+                'type': 'string',
+                'title': 'publicly accessible mms file url'
+            },
+            'mediaVolume': {
+                'type': 'integer',
+                'title': 'set device media volume'
+            },
+            'ringVolume': {
+                'type': 'string',
+                'title': 'set device ring volume'
+            },
+            'alarmVolume': {
+                'type': 'string',
+                'title': 'set device alarm volume'
+            },
+            'wallpaper': {
+                'type': 'string',
+                'title': 'a publicly accessible URL of an image file'
+            },
+            'find': {
+                'type': 'boolean',
+                'title': 'set to true to make your device ring loudly'
+            },
+            'title': {
+                'type': 'string',
+                'title': 'If used, will always create a notification on the receiving device with this as the '
+                         'title and text as the notification’s text'
+            },
+            'icon': {
+                'type': 'string',
+                'title': "notification's icon"
+            },
+            'smallicon': {
+                'type': 'string',
+                'title': 'Status Bar Icon'
+            },
+            'priority': {
+                'type': 'integer',
+                'title': 'control how your notification is displayed',
+                'minimum': -2,
+                'maximum': 2
+            },
+            'group': {
+                'type': 'string',
+                'title': 'allows you to join notifications in different groups'
+            },
+            'image': {
+                'type': 'string',
+                'title': 'Notification image'
+            }
+        },
+        'additionalProperties': False
+    }
 
     @property
     def defaults(self) -> dict:

--- a/notifiers/providers/pushbullet.py
+++ b/notifiers/providers/pushbullet.py
@@ -11,67 +11,67 @@ class Pushbullet(Provider):
     site_url = 'https://www.pushbullet.com'
     provider_name = 'pushbullet'
 
-    @property
-    def schema(self) -> dict:
-        return {
-            'type': 'object',
-            'properties': {
-                'message': {
-                    'type': 'string',
-                    'title': 'Body of the push'
-                },
-                'token': {
-                    'type': 'string',
-                    'title': 'API access token'
-                },
-                'title': {
-                    'type': 'string',
-                    'title': 'Title of the push'
-                },
-                'type': {
-                    'type': 'string',
-                    'title': 'Type of the push, one of "note" or "link"',
-                    'enum': ['note', 'link']
-                },
-                'url': {
-                    'type': 'string',
-                    'title': 'URL field, used for type="link" pushes'
-                },
-                'source_device_iden': {
-                    'type': 'string',
-                    'title': 'Device iden of the sending device'
-                },
-                'device_iden': {
-                    'type': 'string',
-                    'title': 'Device iden of the target device, if sending to a single device'
-                },
-                'client_iden': {
-                    'type': 'string',
-                    'title': 'Client iden of the target client, sends a push to all users who have granted access to '
-                             'this client. The current user must own this client'
-                },
-                'channel_tag': {
-                    'type': 'string',
-                    'title': 'Channel tag of the target channel, sends a push to all people who are subscribed to '
-                             'this channel. The current user must own this channel.'
-                },
-                'email': {
-                    'type': 'string',
-                    'title': 'Email address to send the push to. If there is a pushbullet user with this address,'
-                             ' they get a push, otherwise they get an email'
-                },
-                'guid': {
-                    'type': 'string',
-                    'title': 'Unique identifier set by the client, used to identify a push in case you receive it '
-                             'from /v2/everything before the call to /v2/pushes has completed. This should be a unique'
-                             ' value. Pushes with guid set are mostly idempotent, meaning that sending another push '
-                             'with the same guid is unlikely to create another push (it will return the previously'
-                             ' created push).'
-                }
+    _type = {
+        'type': 'string',
+        'title': 'Type of the push, one of "note" or "link"',
+        'enum': ['note', 'link']
+    }
+    _required = {'required': ['message', 'token']}
+    _schema = {
+        'type': 'object',
+        'properties': {
+            'message': {
+                'type': 'string',
+                'title': 'Body of the push'
             },
-            'required': ['message', 'token'],
-            'additionalProperties': False
-        }
+            'token': {
+                'type': 'string',
+                'title': 'API access token'
+            },
+            'title': {
+                'type': 'string',
+                'title': 'Title of the push'
+            },
+            'type': _type,
+            'type_': _type,
+            'url': {
+                'type': 'string',
+                'title': 'URL field, used for type="link" pushes'
+            },
+            'source_device_iden': {
+                'type': 'string',
+                'title': 'Device iden of the sending device'
+            },
+            'device_iden': {
+                'type': 'string',
+                'title': 'Device iden of the target device, if sending to a single device'
+            },
+            'client_iden': {
+                'type': 'string',
+                'title': 'Client iden of the target client, sends a push to all users who have granted access to '
+                         'this client. The current user must own this client'
+            },
+            'channel_tag': {
+                'type': 'string',
+                'title': 'Channel tag of the target channel, sends a push to all people who are subscribed to '
+                         'this channel. The current user must own this channel.'
+            },
+            'email': {
+                'type': 'string',
+                'title': 'Email address to send the push to. If there is a pushbullet user with this address,'
+                         ' they get a push, otherwise they get an email'
+            },
+            'guid': {
+                'type': 'string',
+                'title': 'Unique identifier set by the client, used to identify a push in case you receive it '
+                         'from /v2/everything before the call to /v2/pushes has completed. This should be a unique'
+                         ' value. Pushes with guid set are mostly idempotent, meaning that sending another push '
+                         'with the same guid is unlikely to create another push (it will return the previously'
+                         ' created push).'
+            }
+        },
+        'additionalProperties': False
+    }
 
     def _get_headers(self, token: str) -> dict:
         return {'Access-Token': token}
@@ -84,6 +84,10 @@ class Pushbullet(Provider):
 
     def _prepare_data(self, data: dict) -> dict:
         data['body'] = data.pop('message')
+
+        # Workaround since `type` is a reserved word
+        if data.get('type_'):
+            data['type'] = data.pop('type_')
         return data
 
     def _send_notification(self, data: dict) -> Response:

--- a/notifiers/providers/pushbullet.py
+++ b/notifiers/providers/pushbullet.py
@@ -11,7 +11,7 @@ class Pushbullet(Provider):
     site_url = 'https://www.pushbullet.com'
     provider_name = 'pushbullet'
 
-    _type = {
+    __type = {
         'type': 'string',
         'title': 'Type of the push, one of "note" or "link"',
         'enum': ['note', 'link']
@@ -32,8 +32,8 @@ class Pushbullet(Provider):
                 'type': 'string',
                 'title': 'Title of the push'
             },
-            'type': _type,
-            'type_': _type,
+            'type': __type,
+            'type_': __type,
             'url': {
                 'type': 'string',
                 'title': 'URL field, used for type="link" pushes'

--- a/notifiers/providers/pushover.py
+++ b/notifiers/providers/pushover.py
@@ -10,7 +10,7 @@ class Pushover(Provider):
     site_url = 'https://pushover.net/'
     provider_name = 'pushover'
 
-    _sounds = ['pushover', 'bike', 'bugle', 'cashregister', 'classical', 'cosmic', 'falling', 'gamelan', 'incoming',
+    __sounds = ['pushover', 'bike', 'bugle', 'cashregister', 'classical', 'cosmic', 'falling', 'gamelan', 'incoming',
                'intermission', 'magic', 'mechanical', 'pianobar', 'siren', 'spacealarm', 'tugboat', 'alien', 'climb',
                'persistent', 'echo', 'updown', 'none']
     _required = {'required': ['user', 'message', 'token']}
@@ -56,7 +56,7 @@ class Pushover(Provider):
                 'type': 'string',
                 'title': "the name of one of the sounds supported by device clients to override the "
                          "user's default sound choice",
-                'enum': _sounds
+                'enum': __sounds
             },
             'timestamp': {
                 'type': 'integer',
@@ -118,5 +118,5 @@ class Pushover(Provider):
     @property
     def metadata(self) -> dict:
         m = super().metadata
-        m['sounds'] = self._sounds
+        m['sounds'] = self.__sounds
         return m

--- a/notifiers/providers/pushover.py
+++ b/notifiers/providers/pushover.py
@@ -9,90 +9,88 @@ class Pushover(Provider):
     base_url = 'https://api.pushover.net/1/messages.json'
     site_url = 'https://pushover.net/'
     provider_name = 'pushover'
-    sounds = ['pushover', 'bike', 'bugle', 'cashregister', 'classical', 'cosmic', 'falling', 'gamelan', 'incoming',
-              'intermission', 'magic', 'mechanical', 'pianobar', 'siren', 'spacealarm', 'tugboat', 'alien', 'climb',
-              'persistent', 'echo', 'updown', 'none']
 
-    @property
-    def schema(self) -> dict:
-        return {
-            'type': 'object',
-            'properties': {
-                'user': one_or_more({
-                    'type': 'string',
-                    'title': 'the user/group key (not e-mail address) of your user (or you)'
-                }),
-                'message': {
-                    'type': 'string',
-                    'title': 'your message'
-                },
-                'title': {
-                    'type': 'string',
-                    'title': "your message's title, otherwise your app's name is used"
-                },
-                'token': {
-                    'type': 'string',
-                    'title': "your application's API token"
-                },
-                'device': one_or_more({
-                    'type': 'string',
-                    'title': "your user's device name to send the message directly to that device"
-                }),
-                'priority': {
-                    'type': 'number',
-                    'minimum': -2,
-                    'maximum': 2,
-                    'title': 'notification priority'
-                },
-                'url': {
-                    'type': 'string',
-                    'format': 'uri',
-                    'title': 'a supplementary URL to show with your message'
-                },
-                'url_title': {
-                    'type': 'string',
-                    'title': 'a title for your supplementary URL, otherwise just the URL is shown'
-                },
-                'sound': {
-                    'type': 'string',
-                    'title': "the name of one of the sounds supported by device clients to override the "
-                             "user's default sound choice",
-                    'enum': self.sounds
-                },
-                'timestamp': {
-                    'type': 'integer',
-                    'minimum': 0,
-                    'title': "a Unix timestamp of your message's date and time to display to the user, "
-                             "rather than the time your message is received by our API"
-                },
-                'retry': {
-                    'type': 'integer',
-                    'minimum': 30,
-                    'title': 'how often (in seconds) the Pushover servers will send the same notification to the '
-                             'user. priority must be set to 2'
-                },
-                'expire': {
-                    'type': 'integer',
-                    'maximum': 86400,
-                    'title': 'how many seconds your notification will continue to be retried for. '
-                             'priority must be set to 2'
-                },
-                'callback': {
-                    'type': 'string',
-                    'format': 'uri',
-                    'title': 'a publicly-accessible URL that our servers will send a request to when the user'
-                             ' has acknowledged your notification. priority must be set to 2'
-                },
-                'html': {
-                    'type': 'integer',
-                    'minimum': 0,
-                    'maximum': 1,
-                    'title': 'enable HTML formatting'
-                }
+    _sounds = ['pushover', 'bike', 'bugle', 'cashregister', 'classical', 'cosmic', 'falling', 'gamelan', 'incoming',
+               'intermission', 'magic', 'mechanical', 'pianobar', 'siren', 'spacealarm', 'tugboat', 'alien', 'climb',
+               'persistent', 'echo', 'updown', 'none']
+    _required = {'required': ['user', 'message', 'token']}
+    _schema = {
+        'type': 'object',
+        'properties': {
+            'user': one_or_more({
+                'type': 'string',
+                'title': 'the user/group key (not e-mail address) of your user (or you)'
+            }),
+            'message': {
+                'type': 'string',
+                'title': 'your message'
             },
-            'required': ['user', 'message', 'token'],
-            'additionalProperties': False
-        }
+            'title': {
+                'type': 'string',
+                'title': "your message's title, otherwise your app's name is used"
+            },
+            'token': {
+                'type': 'string',
+                'title': "your application's API token"
+            },
+            'device': one_or_more({
+                'type': 'string',
+                'title': "your user's device name to send the message directly to that device"
+            }),
+            'priority': {
+                'type': 'number',
+                'minimum': -2,
+                'maximum': 2,
+                'title': 'notification priority'
+            },
+            'url': {
+                'type': 'string',
+                'format': 'uri',
+                'title': 'a supplementary URL to show with your message'
+            },
+            'url_title': {
+                'type': 'string',
+                'title': 'a title for your supplementary URL, otherwise just the URL is shown'
+            },
+            'sound': {
+                'type': 'string',
+                'title': "the name of one of the sounds supported by device clients to override the "
+                         "user's default sound choice",
+                'enum': _sounds
+            },
+            'timestamp': {
+                'type': 'integer',
+                'minimum': 0,
+                'title': "a Unix timestamp of your message's date and time to display to the user, "
+                         "rather than the time your message is received by our API"
+            },
+            'retry': {
+                'type': 'integer',
+                'minimum': 30,
+                'title': 'how often (in seconds) the Pushover servers will send the same notification to the '
+                         'user. priority must be set to 2'
+            },
+            'expire': {
+                'type': 'integer',
+                'maximum': 86400,
+                'title': 'how many seconds your notification will continue to be retried for. '
+                         'priority must be set to 2'
+            },
+            'callback': {
+                'type': 'string',
+                'format': 'uri',
+                'title': 'a publicly-accessible URL that our servers will send a request to when the user'
+                         ' has acknowledged your notification. priority must be set to 2'
+            },
+            'html': {
+                'type': 'integer',
+                'minimum': 0,
+                'maximum': 1,
+                'title': 'enable HTML formatting'
+            }
+        },
+        'additionalProperties': False
+    }
 
     def _prepare_data(self, data: dict) -> dict:
         data['user'] = list_to_commas(data['user'])
@@ -120,5 +118,5 @@ class Pushover(Provider):
     @property
     def metadata(self) -> dict:
         m = super().metadata
-        m['sounds'] = self.sounds
+        m['sounds'] = self._sounds
         return m

--- a/notifiers/providers/simplepush.py
+++ b/notifiers/providers/simplepush.py
@@ -9,31 +9,29 @@ class SimplePush(Provider):
     site_url = 'https://simplepush.io/'
     provider_name = 'simplepush'
 
-    @property
-    def schema(self) -> dict:
-        return {
-            'type': 'object',
-            'properties': {
-                'key': {
-                    'type': 'string',
-                    'title': 'your user key'
-                },
-                'message': {
-                    'type': 'string',
-                    'title': 'your message'
-                },
-                'title': {
-                    'type': 'string',
-                    'title': 'message title'
-                },
-                'event': {
-                    'type': 'string',
-                    'title': 'Event ID'
-                },
+    _required = {'required': ['key', 'message']}
+    _schema = {
+        'type': 'object',
+        'properties': {
+            'key': {
+                'type': 'string',
+                'title': 'your user key'
             },
-            'required': ['key', 'message'],
-            'additionalProperties': False
-        }
+            'message': {
+                'type': 'string',
+                'title': 'your message'
+            },
+            'title': {
+                'type': 'string',
+                'title': 'message title'
+            },
+            'event': {
+                'type': 'string',
+                'title': 'Event ID'
+            },
+        },
+        'additionalProperties': False
+    }
 
     def _prepare_data(self, data: dict) -> dict:
         data['msg'] = data.pop('message')

--- a/notifiers/providers/slack.py
+++ b/notifiers/providers/slack.py
@@ -9,134 +9,138 @@ class Slack(Provider):
     site_url = 'https://api.slack.com/incoming-webhooks'
     provider_name = 'slack'
 
-    @property
-    def schema(self) -> dict:
-        return {
+    _fields = {
+        'type': 'array',
+        'title': 'Fields are displayed in a table on the message',
+        'minItems': 1,
+        'items': {
             'type': 'object',
             'properties': {
-                'webhook_url': {
+                'title': {
                     'type': 'string',
-                    'title': 'the webhook URL to use.'
-                             ' Register one at https://my.slack.com/services/new/incoming-webhook/'
+                    'title': 'Required Field Title'
                 },
-                'icon_url': {
+                'value': {
                     'type': 'string',
-                    'title': 'override bot icon with image URL'
+                    'title': 'Text value of the field. May contain standard message markup and must'
+                             ' be escaped as normal. May be multi-line'
                 },
-                'icon_emoji': {
-                    'type': 'string',
-                    'title': 'override bot icon with emoji name.'
-                },
-                'username': {
-                    'type': 'string',
-                    'title': 'override the displayed bot name'
-                },
-                'channel': {
-                    'type': 'string',
-                    'title': 'override default channel or private message'
-                },
-                'unfurl_links': {
+                'short': {
                     'type': 'boolean',
-                    'title': 'avoid automatic attachment creation from URLs'
-                },
-                'message': {
-                    'type': 'string',
-                    'title': 'This is the text that will be posted to the channel'
-                },
-                'attachments': {
-                    'type': 'array',
-                    'items': {
-                        'type': 'object',
-                        'properties': {
-                            'title': {
-                                'type': 'string',
-                                'title': 'Attachment title'
-                            },
-                            'author_name': {
-                                'type': 'string',
-                                'title': "Small text used to display the author's name"
-                            },
-                            'author_link': {
-                                'type': 'string',
-                                'title': 'A valid URL that will hyperlink the author_name text mentioned above. Will only work if author_name is present'
-                            },
-                            'author_icon': {
-                                'type': 'string',
-                                'title': 'A valid URL that displays a small 16x16px image to the left of the author_name text. Will only work if author_name is present'
-                            },
-                            'title_link': {
-                                'type': 'string',
-                                'title': 'Attachment title URL'
-                            },
-                            'image_url': {
-                                'type': 'string',
-                                'title': 'Image URL'
-                            },
-                            'thumb_url': {
-                                'type': 'string',
-                                'title': 'Thumbnail URL'
-                            },
-                            'footer': {
-                                'type': 'string',
-                                'title': 'Footer text'
-                            },
-                            'footer_icon': {
-                                'type': 'string',
-                                'title': 'Footer icon URL'
-                            },
-                            'ts': {
-                                'type': 'integer',
-                                'title': 'Provided timestamp (epoch)'
-                            },
-                            'fallback': {
-                                'type': 'string',
-                                'title': "A plain-text summary of the attachment. This text will be used in clients that don't show formatted text (eg. IRC, mobile notifications) and should not contain any markup."
-                            },
-                            'text': {
-                                'type': 'string',
-                                'title': 'Optional text that should appear within the attachment'
-                            },
-                            'pretext': {
-                                'type': 'string',
-                                'title': 'Optional text that should appear above the formatted data'
-                            },
-                            'color': {
-                                'type': 'string',
-                                'title': "Can either be one of 'good', 'warning', 'danger', or any hex color code"
-                            },
-                            'fields': {
-                                'type': 'array',
-                                'title': 'Fields are displayed in a table on the message',
-                                'minItems': 1,
-                                'items': {
-                                    'type': 'object',
-                                    'properties': {
-                                        'title': {
-                                            'type': 'string',
-                                            'title': 'Required Field Title'
-                                        },
-                                        'value': {
-                                            'type': 'string',
-                                            'title': 'Text value of the field. May contain standard message markup and must be escaped as normal. May be multi-line'
-                                        },
-                                        'short': {
-                                            'type': 'boolean',
-                                            'title': 'Optional flag indicating whether the `value` is short enough to be displayed side-by-side with other values'
-                                        }
-                                    },
-                                    'required': ['title'],
-                                    'additionalProperties': False
-                                }
-                            }
-                        },
-                        'required': ['fallback'],
-                        'additionalProperties': False
-                    }
+                    'title': 'Optional flag indicating whether the `value` is short enough to be displayed'
+                             ' side-by-side with other values'
                 }
             },
-            'required': ['webhook_url', 'message'],
+            'required': ['title'],
             'additionalProperties': False
         }
+    }
+    _attachments = {
+        'type': 'array',
+        'items': {
+            'type': 'object',
+            'properties': {
+                'title': {
+                    'type': 'string',
+                    'title': 'Attachment title'
+                },
+                'author_name': {
+                    'type': 'string',
+                    'title': "Small text used to display the author's name"
+                },
+                'author_link': {
+                    'type': 'string',
+                    'title': 'A valid URL that will hyperlink the author_name text mentioned above. '
+                             'Will only work if author_name is present'
+                },
+                'author_icon': {
+                    'type': 'string',
+                    'title': 'A valid URL that displays a small 16x16px image to the left of the author_name text. '
+                             'Will only work if author_name is present'
+                },
+                'title_link': {
+                    'type': 'string',
+                    'title': 'Attachment title URL'
+                },
+                'image_url': {
+                    'type': 'string',
+                    'title': 'Image URL'
+                },
+                'thumb_url': {
+                    'type': 'string',
+                    'title': 'Thumbnail URL'
+                },
+                'footer': {
+                    'type': 'string',
+                    'title': 'Footer text'
+                },
+                'footer_icon': {
+                    'type': 'string',
+                    'title': 'Footer icon URL'
+                },
+                'ts': {
+                    'type': 'integer',
+                    'title': 'Provided timestamp (epoch)'
+                },
+                'fallback': {
+                    'type': 'string',
+                    'title': "A plain-text summary of the attachment. This text will be used in clients that don't"
+                             " show formatted text (eg. IRC, mobile notifications) and should not contain any markup."
+                },
+                'text': {
+                    'type': 'string',
+                    'title': 'Optional text that should appear within the attachment'
+                },
+                'pretext': {
+                    'type': 'string',
+                    'title': 'Optional text that should appear above the formatted data'
+                },
+                'color': {
+                    'type': 'string',
+                    'title': "Can either be one of 'good', 'warning', 'danger', or any hex color code"
+                },
+                'fields': _fields
+            },
+            'required': ['fallback'],
+            'additionalProperties': False
+        }
+    }
+    _required = {'required': ['webhook_url', 'message']}
+    _schema = {
+        'type': 'object',
+        'properties': {
+            'webhook_url': {
+                'type': 'string',
+                'title': 'the webhook URL to use. Register one at https://my.slack.com/services/new/incoming-webhook/'
+            },
+            'icon_url': {
+                'type': 'string',
+                'title': 'override bot icon with image URL'
+            },
+            'icon_emoji': {
+                'type': 'string',
+                'title': 'override bot icon with emoji name.'
+            },
+            'username': {
+                'type': 'string',
+                'title': 'override the displayed bot name'
+            },
+            'channel': {
+                'type': 'string',
+                'title': 'override default channel or private message'
+            },
+            'unfurl_links': {
+                'type': 'boolean',
+                'title': 'avoid automatic attachment creation from URLs'
+            },
+            'message': {
+                'type': 'string',
+                'title': 'This is the text that will be posted to the channel'
+            },
+            'attachments': _attachments
+        },
+        'additionalProperties': False
+    }
 
     def _prepare_data(self, data: dict) -> dict:
         text = data.pop('message')
@@ -144,7 +148,7 @@ class Slack(Provider):
         if data.get('icon_emoji'):
             icon_emoji = data['icon_emoji']
             if not icon_emoji.startswith(':'):
-                icon_emoji = ':' + icon_emoji
+                icon_emoji = f':{icon_emoji}'
             if not icon_emoji.endswith(':'):
                 icon_emoji += ':'
             data['icon_emoji'] = icon_emoji

--- a/notifiers/providers/slack.py
+++ b/notifiers/providers/slack.py
@@ -9,7 +9,7 @@ class Slack(Provider):
     site_url = 'https://api.slack.com/incoming-webhooks'
     provider_name = 'slack'
 
-    _fields = {
+    __fields = {
         'type': 'array',
         'title': 'Fields are displayed in a table on the message',
         'minItems': 1,
@@ -35,7 +35,7 @@ class Slack(Provider):
             'additionalProperties': False
         }
     }
-    _attachments = {
+    __attachments = {
         'type': 'array',
         'items': {
             'type': 'object',
@@ -99,7 +99,7 @@ class Slack(Provider):
                     'type': 'string',
                     'title': "Can either be one of 'good', 'warning', 'danger', or any hex color code"
                 },
-                'fields': _fields
+                'fields': __fields
             },
             'required': ['fallback'],
             'additionalProperties': False
@@ -137,7 +137,7 @@ class Slack(Provider):
                 'type': 'string',
                 'title': 'This is the text that will be posted to the channel'
             },
-            'attachments': _attachments
+            'attachments': __attachments
         },
         'additionalProperties': False
     }

--- a/notifiers/providers/telegram.py
+++ b/notifiers/providers/telegram.py
@@ -10,52 +10,50 @@ class Telegram(Provider):
     provider_name = 'telegram'
     site_url = 'https://core.telegram.org/'
 
-    @property
-    def schema(self) -> dict:
-        return {
-            'type': 'object',
-            'properties': {
-                'message': {
-                    'type': 'string',
-                    'title': 'Text of the message to be sent'
-                },
-                'token': {
-                    'type': 'string',
-                    'title': 'Bot token'
-                },
-                'chat_id': {
-                    'type': [
-                        'string',
-                        'integer'
-                    ],
-                    'title': 'Unique identifier for the target chat or username of the target channel '
-                             '(in the format @channelusername)'
-                },
-                'parse_mode': {
-                    'type': 'string',
-                    'title': "Send Markdown or HTML, if you want Telegram apps to show bold, italic,"
-                             " fixed-width text or inline URLs in your bot's message.",
-                    'enum': [
-                        'markdown',
-                        'html'
-                    ]
-                },
-                'disable_web_page_preview': {
-                    'type': 'boolean',
-                    'title': 'Disables link previews for links in this message'
-                },
-                'disable_notification': {
-                    'type': 'boolean',
-                    'title': 'Sends the message silently. Users will receive a notification with no sound.'
-                },
-                'reply_to_message_id': {
-                    'type': 'integer',
-                    'title': 'If the message is a reply, ID of the original message'
-                }
+    _required = {'required': ['message', 'chat_id', 'token']}
+    _schema = {
+        'type': 'object',
+        'properties': {
+            'message': {
+                'type': 'string',
+                'title': 'Text of the message to be sent'
             },
-            'required': ['message', 'chat_id', 'token'],
-            'additionalProperties': False
-        }
+            'token': {
+                'type': 'string',
+                'title': 'Bot token'
+            },
+            'chat_id': {
+                'type': [
+                    'string',
+                    'integer'
+                ],
+                'title': 'Unique identifier for the target chat or username of the target channel '
+                         '(in the format @channelusername)'
+            },
+            'parse_mode': {
+                'type': 'string',
+                'title': "Send Markdown or HTML, if you want Telegram apps to show bold, italic,"
+                         " fixed-width text or inline URLs in your bot's message.",
+                'enum': [
+                    'markdown',
+                    'html'
+                ]
+            },
+            'disable_web_page_preview': {
+                'type': 'boolean',
+                'title': 'Disables link previews for links in this message'
+            },
+            'disable_notification': {
+                'type': 'boolean',
+                'title': 'Sends the message silently. Users will receive a notification with no sound.'
+            },
+            'reply_to_message_id': {
+                'type': 'integer',
+                'title': 'If the message is a reply, ID of the original message'
+            }
+        },
+        'additionalProperties': False
+    }
 
     def _prepare_data(self, data: dict) -> dict:
         data['text'] = data.pop('message')

--- a/notifiers/providers/zulip.py
+++ b/notifiers/providers/zulip.py
@@ -11,7 +11,7 @@ class Zulip(Provider):
     api_endpoint = '/api/v1/messages'
     base_url = 'https://{domain}.zulipchat.com'
 
-    __required = {
+    _required = {
         'allOf': [
             {'required': ['message', 'email', 'api_key', 'to']},
             {'oneOf': [
@@ -20,13 +20,13 @@ class Zulip(Provider):
             ]}
         ]
     }
-    __type = {
+    _type = {
         'type': 'string',
         'enum': ['stream', 'private'],
         'title': 'Type of message to send'
     }
 
-    __schema = {
+    _schema = {
         'type': 'object',
         'properties': {
             'message': {
@@ -41,8 +41,8 @@ class Zulip(Provider):
                 'type': 'string',
                 'title': 'User API Key'
             },
-            'type': __type,
-            'type_': __type,
+            'type': _type,
+            'type_': _type,
             'to': {
                 'type': 'string',
                 'title': 'Target of the message'
@@ -62,12 +62,6 @@ class Zulip(Provider):
         },
         'additionalProperties': False
     }
-
-    @property
-    def schema(self) -> dict:
-        schema = self.__schema
-        schema.update(self.__required)
-        return schema
 
     @property
     def defaults(self) -> dict:

--- a/notifiers/providers/zulip.py
+++ b/notifiers/providers/zulip.py
@@ -11,6 +11,11 @@ class Zulip(Provider):
     api_endpoint = '/api/v1/messages'
     base_url = 'https://{domain}.zulipchat.com'
 
+    __type = {
+        'type': 'string',
+        'enum': ['stream', 'private'],
+        'title': 'Type of message to send'
+    }
     _required = {
         'allOf': [
             {'required': ['message', 'email', 'api_key', 'to']},
@@ -19,11 +24,6 @@ class Zulip(Provider):
                 {'required': ['server']}
             ]}
         ]
-    }
-    _type = {
-        'type': 'string',
-        'enum': ['stream', 'private'],
-        'title': 'Type of message to send'
     }
 
     _schema = {
@@ -41,8 +41,8 @@ class Zulip(Provider):
                 'type': 'string',
                 'title': 'User API Key'
             },
-            'type': _type,
-            'type_': _type,
+            'type': __type,
+            'type_': __type,
             'to': {
                 'type': 'string',
                 'title': 'Target of the message'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,12 +9,13 @@ from notifiers.utils.helpers import text_to_bool
 
 
 @pytest.fixture
-def mock_provider(monkeypatch) -> Provider:
+def mock_provider(monkeypatch):
     """Return a generic :class:``notifiers.Provider`` class"""
 
     class MockProvider(Provider):
         base_url = 'https://api.mock.com'
-        schema = {
+        _required = {'required': ['required']}
+        _schema = {
             'type': 'object',
             'properties': {
                 'not_required': one_or_more({'type': 'string'}),
@@ -22,7 +23,6 @@ def mock_provider(monkeypatch) -> Provider:
                 'option_with_default': {'type': 'string'},
                 'message': {'type': 'string'}
             },
-            'required': ['required'],
             'additionalProperties': False
         }
         site_url = 'https://www.mock.com'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,7 +28,7 @@ class TestCore:
             'option_with_default': {'type': 'string'}
         }
 
-        assert p.required == ['required']
+        assert p.required == {'required': ['required']}
         rsp = p.notify(**self.valid_data)
         assert isinstance(rsp, Response)
         assert not rsp.errors
@@ -51,7 +51,7 @@ class TestCore:
     def test_bad_schema(self, mock_provider):
         """Test illegal JSON schema"""
         p = mock_provider()
-        p.schema = {'type': 'bad_schema'}
+        p._schema = {'type': 'bad_schema'}
         data = {'foo': 'bar'}
         with pytest.raises(SchemaError):
             p.notify(**data)


### PR DESCRIPTION
This more accurately represents providers' required element since it can a more complex pattern than a simple list. Specific override of `required` property method is not longer needed.

Note: This changes the API response pattern a bit, potentially (minor) breaking change