### PR TITLE
Make exceptions more readable

### DIFF
--- a/notifiers/exceptions.py
+++ b/notifiers/exceptions.py
@@ -10,11 +10,10 @@ class NotifierException(Exception):
         self.provider = kwargs['provider']
         self.message = kwargs.pop('message', None)
         self.data = kwargs.pop('data', None)
+        super().__init__(self.message)
 
     def __repr__(self):
         return f'<NotificationError: {self.message}>'
-
-    __str__ = __repr__
 
 
 class BadArguments(NotifierException):


### PR DESCRIPTION
In my opinion, a repr is a little harsh on the eyes while reading a traceback.

I haven't tested the change, but
``notifiers.exceptions.BadArguments: <NotificationError: Error with sent data: 'user' is a required property>``
should become
``notifiers.exceptions.BadArguments: Error with sent data: 'user' is a required property``