### PR TITLE
SendGrid integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.pytest_cache/
 
 # C extensions
 *.so
@@ -87,6 +88,9 @@ celerybeat-schedule
 venv/
 ENV/
 
+# pipenv
+Pipfile*
+
 # Spyder project settings
 .spyderproject
 .spyproject
@@ -101,3 +105,6 @@ ENV/
 .mypy_cache/
 poc*
 /docs/
+
+# vim swap files
+.*.sw*

--- a/README.MD
+++ b/README.MD
@@ -13,7 +13,7 @@ Got an app or service and you want to enable your users to use notifications wit
 Supported providers
 -------------------
 
-[Pushover](https://pushover.net/), [SimplePush](https://simplepush.io/), [Slack](https://api.slack.com/), [Gmail](https://www.google.com/gmail/about/), Email (SMTP), [Telegram](https://telegram.org/), [Gitter](https://gitter.im), [Pushbullet](https://www.pushbullet.com), [Join](https://joaoapps.com/join/), [Hipchat](https://www.hipchat.com/docs/apiv2), [Zulip](https://zulipchat.com/), [Twilio](https://www.twilio.com/), [Pagerduty](https://www.pagerduty.com), [Mailgun](https://www.mailgun.com/), [PopcornNotify](https://popcornnotify.com), [StatusPage.io](https://statuspage.io)
+[Pushover](https://pushover.net/), [SimplePush](https://simplepush.io/), [Slack](https://api.slack.com/), [Gmail](https://www.google.com/gmail/about/), Email (SMTP), [Telegram](https://telegram.org/), [Gitter](https://gitter.im), [Pushbullet](https://www.pushbullet.com), [Join](https://joaoapps.com/join/), [Hipchat](https://www.hipchat.com/docs/apiv2), [Zulip](https://zulipchat.com/), [Twilio](https://www.twilio.com/), [Pagerduty](https://www.pagerduty.com), [Mailgun](https://www.mailgun.com/), [PopcornNotify](https://popcornnotify.com), [StatusPage.io](https://statuspage.io), [SendGrid](https://www.sendgrid.com)
 
 Advantages
 ----------

--- a/notifiers/providers/__init__.py
+++ b/notifiers/providers/__init__.py
@@ -1,12 +1,13 @@
 from . import (
     pushover, simplepush, slack, email, gmail, telegram, gitter, pushbullet, join, hipchat, zulip, twilio, pagerduty,
-    mailgun, popcornnotify, statuspage
+    mailgun, popcornnotify, statuspage, sendgrid
 )
 
 _all_providers = {
     'pushover': pushover.Pushover,
     'simplepush': simplepush.SimplePush,
     'slack': slack.Slack,
+    'sendgrid': sendgrid.SendGrid,
     'email': email.SMTP,
     'gmail': gmail.Gmail,
     'telegram': telegram.Telegram,

--- a/notifiers/providers/sendgrid.py
+++ b/notifiers/providers/sendgrid.py
@@ -1,0 +1,608 @@
+import json
+
+from ..core import Provider, Response
+from ..utils import requests
+from ..utils.schema.helpers import one_or_more
+
+
+class SendGrid(Provider):
+    """Send emails via SendGrid"""
+    base_url = 'https://api.sendgrid.com/v3/mail/send'
+    site_url = 'https://sendgrid.com/docs'
+    name = 'sendgrid'
+    # TODO what is this?
+    path_to_errors = 'message',
+
+    # TODO what is this? why do we specify the top level required seperately?
+    _required = {
+        'allOf': [
+            {
+                'required': [
+                    'subject',
+                ]
+            },
+            {
+                'anyOf': [
+                    {
+                        'required': [
+                            'to'
+                        ]
+                    },
+                    {
+                        'required': [
+                            'personalizations'
+                        ]
+                    }
+                ]
+            },
+            {
+                'anyOf': [
+                    {
+                        'required': [
+                            'from'
+                        ]
+                    },
+                    {
+                        'required': [
+                            'from_'
+                        ]
+                    }
+                ],
+            },
+            {
+                'anyOf': [
+                    {
+                        'required': [
+                            'content'
+                        ]
+                    },
+                    {
+                        'required': [
+                            'message'
+                        ]
+                    }
+                ]
+            }
+        ],
+    }
+
+    __recipient_array = {
+        'type': 'array',
+        'title': 'A list of recipients',
+        'minItems': 1,
+        'maxItems': 1000,
+        'uniqueItems': False,
+        'items': {
+            'type': 'object',
+            'required': ['email'],
+            'properties': {
+                'email': {
+                    'type': 'string',
+                    'title': 'Email address of recipient',
+                    'format': 'email'
+                },
+                'name': {
+                    'type': 'string',
+                    'title': 'Name of recipient'
+                }
+            }
+        }
+    }
+
+    __from = {
+        'type': 'object',
+        'title': 'The from address of the email',
+        'additionalProperties': False,
+        'required': ['email'],
+        'properties': {
+            'email': {
+                'type': 'string',
+                'title': 'The email address'
+            },
+            'name': {
+                'type': 'string',
+                'title': 'The name associated with the email address'
+            }
+        }
+    }
+
+    _schema = {
+        'type': 'object',
+        'properties': {
+            'to': {
+                'type': 'string',
+                'title': 'The destination address of the email, will override' +
+                         ' and replace any provided personalizations',
+                'format': 'email'
+            },
+            'api_key': {
+                'type': 'string',
+                'title': 'API key for authorization'
+            },
+            'personalizations': {
+                'type': 'array',
+                'title': 'An array of messages and their metadata',
+                'items': {
+                    'additionalProperties': False,
+                    'type': 'object',
+                    'required': ['to'],
+                    'properties': {
+                        'to': __recipient_array,
+                        'cc': __recipient_array,
+                        'bcc': __recipient_array,
+                        'subject': {
+                            'minLength': 1,
+                            'type': 'string',
+                            'title': 'Subject of the personalized message'
+                        },
+                        'headers': {
+                            'type': 'object',
+                            'title': 'A collection of key/value pairs ' +
+                                     'indicating headers to be overridden ' +
+                                     'in this email'
+                        },
+                        'substitutions': {
+                            'type': 'object',
+                            'title': 'A collection of key/value pairs that will ' +
+                                     'be applied to the text and html parts of the email',
+                            'maxProperties': 10000
+                        },
+                        'custom_args': {
+                            'type': 'object',
+                            'title': 'Values that are specific to this ' +
+                                     'personalization that will be carried' +
+                                     ' along with the email and its activity data',
+                            'maxProperties': 10000
+                        },
+                        'send_at': {
+                            'type': 'integer',
+                            'title': 'A unix timestamp allowing you to ' +
+                                     'specify when you want your email ' + 
+                                     'to be delivered',
+                        }
+
+                    }
+                }
+            },
+            'message': {
+                'type': 'string',
+                'title': 'Plain text message content'
+            },
+            'from': __from,
+            'from_': __from,
+            'reply_to': {
+                'type': 'object',
+                'title': 'The "reply to" address of the email',
+                'additionalProperties': False,
+                'required': ['email'],
+                'properties': {
+                    'email': {
+                        'type': 'string',
+                        'title': 'The email address'
+                    },
+                    'name': {
+                        'type': 'string',
+                        'title': 'The name associated with the email address'
+                    }
+                }
+            },
+            'subject': {
+                    'type': 'string',
+                    'title': 'The global subject of the message',
+                    'minLength': 1
+            },
+            'content': {
+                    'type': 'array',
+                    'title': 'An array in which you may specify the content' +
+                             ' of your email by mime type',
+                    'items': {
+                        'additionalProperties': False,
+                        'required': ['type', 'value'],
+                        'properties': {
+                            'type': {
+                                'type': 'string',
+                                'minLength': 1,
+                                'title': 'The mime type of this message part' +
+                                         ' e.g "text/html"'
+                            },
+                            'value': {
+                                'type': 'string',
+                                'minLength': 1,
+                                'title': 'The actual content of the specified' +
+                                         ' mime type'
+                            }
+                        }
+                    }
+                },
+            'attachments': {
+                    'type': 'array',
+                    'title': 'An array of attachments for your email',
+                    'items': {
+                        'additionalProperties': False,
+                        'required': ['content', 'filename'],
+                        'properties': {
+                            'content': {
+                                'type': 'string',
+                                'title': 'The base64 encoded content of the' +
+                                         ' attachment',
+                                'minLength': 1,
+                            },
+                            'type': {
+                                'type': 'string',
+                                'title': 'The mime type of the attachment',
+                                'minLength': 1
+                            },
+                            'filename': {
+                                'type': 'string',
+                                'title': 'The filename of the attachment',
+                                'minLength': 1
+                            },
+                            'disposition': {
+                                'type': 'string',
+                                'default': 'attachment',
+                                'enum': [
+                                    'inline',
+                                    'attachment'
+                                ]
+                            },
+                            'content_id': {
+                                'type': 'string',
+                                'title': 'the content ID for the attachment' +
+                                         ', used when disposition is ' +
+                                          '"inline"',
+                            }
+                        }
+                    }
+            },
+            'template_id': {
+                    'type': 'string',
+                    'title': 'The ID of the template you would like to use'
+            },
+            'sections': {
+                    'type': 'object',
+                    'title': 'An object of key/value pairs that define ' +
+                            'block sections to be used for substitutions'
+            },
+            'headers': {
+                'type': 'object',
+                'title': 'A collection of key/value pairs ' +
+                         'indicating headers to be overridden ' +
+                         'in this email'
+            },
+            'categories': {
+                'type': 'array',
+                'title': 'An array of category names for this message',
+                'uniqueItems': True,
+                'maxItems': 10,
+                'items': {
+                    'type': 'string',
+                    'maxLength': 255
+                }
+            },
+            'custom_args': {
+                'type': 'object',
+                'title': 'Values that are specific to the entire send ' +
+                         'that will be carried along with the email and ' +
+                         'its activity data'
+            },
+            'send_at': {
+                'type': 'integer',
+                'title': 'A unix timestamp allowing you to specify when ' +
+                         'you want your email to be delivered'
+            },
+            'batch_id': {
+                'type': 'string',
+                'title': 'This ID represents a batch of emails to be sent at the same time.'
+            },
+            'asm': {
+                'type': 'object',
+                'title': 'An object allowing you to specify how to ' +
+                         'handle unsubscribes.',
+                'additionalProperties': False,
+                'required': ['group_id'],
+                'properties': {
+                    'group_id': {
+                        'type': 'integer',
+                        'title': 'The unsubscribe group to associate with ' +
+                                 'this email'
+                    },
+                    'groups_to_display': {
+                        'type': 'array',
+                        'title': 'An array containing the unsubscribe ' +
+                                 'groups that you would like to be' + 
+                                ' displayed on the unsubscribe preferences' + 
+                                ' page.',
+                        'maxItems': 25,
+                        'items': {
+                            'type': 'integer'
+                        }
+                    }
+                }
+            },
+            'ip_pool_name': {
+                'type': 'string',
+                'title': 'The IP Pool that you would like to send this ' +
+                         'email from.',
+                'minLength': 2,
+                'maxLength': 64
+            },
+            'mail_settings': {
+                'type': 'object',
+                'title': 'A collection of different mail settings that you ' +
+                         'can use to specify how you would like this email ' +
+                         'to be handled.',
+                'additionalProperties': False,
+                'properties': {
+                    'bcc': {
+                        'type': 'object',
+                        'title': 'This allows you to have a blind carbon ' +
+                                 'copy automatically sent to the specified ' +
+                                 'email address for every email that is sent.',
+                        'additionalProperties': False,
+                        'properties': {
+                            'email': {
+                                'format': 'email',
+                                'type': 'string',
+                                'title': 'The email address that you would ' +
+                                         'like to receive the BCC',
+                            },
+                            'enable': {
+                                'type': 'boolean',
+                                'title': 'Indicates if this setting is ' +
+                                         'enabled.'
+                            }
+                        }
+                    },
+                    'bypass_list_management': {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'title': 'Allows you to bypass all unsubscribe ' + 
+                                 'groups and suppressions to ensure that ' +
+                                 'the email is delivered to every single ' +
+                                 'recipient.',
+                        'properties': {
+                            'enable': {
+                                'type': 'boolean',
+                                'title': 'Indicates if this setting is enabled.'
+                            }
+                        }
+                    },
+                    'footer': {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'title': 'The default footer that you would like ' +
+                                 'included on every email.',
+                        'properties': {
+                            'enable': {
+                                'type': 'boolean',
+                                'title': 'Indicates if this setting is enabled.'
+                            },
+                            'text': {
+                                'type': 'string',
+                                'title': 'The plain text content of your ' +
+                                         'footer.'
+                            },
+                            'html': {
+                                'type': 'string',
+                                'title': 'The HTML content of your footer'
+                            }
+                        }
+                    },
+                    'sandbox_mode': {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'title': 'This allows you to send a test email to ' +
+                                 'ensure that your request body is valid ' +
+                                 'and formatted correctly.',
+                        'properties': {
+                            'enable': {
+                                'type': 'boolean',
+                                'title': 'Indicates if this setting is enabled'
+                            }
+                        }
+                    },
+                    'spam_check': {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'title': 'This allows you to test the content ' +
+                                 'of your email for spam.',
+                        'properties': {
+                            'enable': {
+                                'type': 'boolean',
+                                'title': 'Indicates if this setting is enabled'
+                            },
+                            'threshold': {
+                                'type': 'integer',
+                                'minimum': 1,
+                                'maximum': 10,
+                                'title': 'The threshold used to determine ' +
+                                         'if your content qualifies as spam ' +
+                                         'on a scale from 1 to 10, with 10 ' +
+                                         'being most strict, or most likely ' +
+                                         'to be considered as spam.'
+                            },
+                            'post_to_url': {
+                                'type': 'string',
+                                'title': 'An Inbound Parse URL that you ' +
+                                         'would like a copy of your email ' +
+                                         'along with the spam report to be ' +
+                                         'sent to.'
+                            }
+                        }
+                    }
+                }
+            },
+            'tracking_settings': {
+                'type': 'object',
+                'additionalProperties': False,
+                'title': 'Settings to determine how you would like to ' +
+                         'track the metrics of how your recipients interact '+
+                         'with your email.',
+                'properties': {
+                    'click_tracking': {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'title': 'Allows you to track whether a recipient ' +
+                                 'clicked a link in your email.',
+                        'properties': {
+                            'enable': {
+                                'type': 'boolean',
+                                'title': 'Indicates if this setting is enabled'
+                            },
+                            'enable_text': {
+                                'type': 'boolean',
+                                'title': 'Indicates if this setting should ' +
+                                         'be included in the text/plain ' +
+                                         'portion of your email.'
+                            }
+                        }
+                    },
+                    'open_tracking': {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'title': 'Allows you to track whether the email was ' +
+                                 'opened or not',
+                        'properties': {
+                            'enable': {
+                                'type': 'boolean',
+                                'title': 'Indicates if this setting is enabled'
+                            },
+                            'substitution_tag': {
+                                'type': 'string',
+                                'title': 'Allows you to specify a ' +
+                                         'substitution tag that you can ' +
+                                         'insert in the body of your ' +
+                                         'email at a location that you ' +
+                                         'desire. This tag will be ' +
+                                         'replaced by the open tracking '+
+                                         'pixel.'
+                            }
+                        }
+                    },
+                    'subscription_tracking': {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'title': 'Allows you to insert a subscription ' +
+                                 'management link at the bottom of the text' +
+                                 ' and html bodies of your email. If you' +
+                                 ' would like to specify the location of ' +
+                                 'the link within your email, you may use ' +
+                                 'the substitution_tag.',
+                        'properties': {
+                            'enable': {
+                                'type': 'boolean',
+                                'title': 'Indicates if this setting is enabled'
+                            },
+                            'text': {
+                                'type': 'string',
+                                'title': 'Text to be appended to the email, ' +
+                                         'with the subscription tracking ' +
+                                         'link. You may control where the ' +
+                                         'link is by using the tag <% %>'
+                            },
+                            'html': {
+                                'type': 'string',
+                                'title': 'HTML to be appended to the email, ' +
+                                         'with the subscription tracking ' +
+                                         'link. You may control where the ' +
+                                         'link is by using the tag <% %>'
+                            },
+                            'substitution_tag': {
+                                'type': 'string',
+                                'title': 'A tag that will be replaced with the ' +
+                                         'unsubscribe URL. for example: ' +
+                                         '[unsubscribe_url]. If this ' +
+                                         'parameter is used, it will override' +
+                                         ' both the text and html parameters.' +
+                                         ' The URL of the link will be placed' +
+                                         ' at the substitution tag’s location' +
+                                         ', with no additional formatting.'
+                            }
+                        }
+                    },
+                    'ganalytics': {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'title': 'Allows you to insert a subscription ' +
+                                 'management link at the bottom of the text' +
+                                 ' and html bodies of your email. If you ' +
+                                 'would like to specify the location of the' +
+                                 ' link within your email, you may use the ' +
+                                 'substitution_tag.',
+                        'properties' : {
+                            'enable': {
+                                'type': 'boolean',
+                                'title': 'Indicates if this setting is enabled'
+                            },
+                            'utm_source': {
+                                'type': 'string',
+                                'title': 'Name of the referrer source.' +
+                                         ' (e.g. Google, SomeDomain.com,' +
+                                         ' or Marketing Email)'
+                            },
+                            'utm_medium': {
+                                'type': 'string',
+                                'title': 'Name of the marketing medium. ' +
+                                         '(e.g. Email)'
+                            },
+                            'utm_term': {
+                                'type': 'string',
+                                'title': 'Used to identify any paid keywords.'
+                            },
+                            'utm_content': {
+                                'type': 'string',
+                                'title': 'Used to differentiate your ' +
+                                         'campaign from advertisements.'  
+                            },
+                            'utm_campaign': {
+                                'type': 'string',
+                                'title': 'The name of the campaign'
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        'additionalProperties': False
+    }
+
+    def _prepare_data(self, data: dict) -> dict:
+        if data.get('from_'):
+            data['from'] = data.pop('from_')
+
+        if data.get('message'):
+            content = [
+                {
+                    'type': 'text/plain',
+                    'value': data.pop('message')
+                }
+            ]
+            data['content'] = content
+
+        # inserting support for a 'to' argument, since sendgrid is a little
+        # complicated about setting that
+        if data.get('to'):
+            data['personalizations'] = [
+                {
+                    'to': [
+                            {
+                                'email': data.pop('to')
+                            }
+                        ]
+                }
+            ]
+
+
+        return data
+
+    def _send_notification(self, data: dict) -> Response:
+        headers = {
+            'Authorization': f'Bearer {data["api_key"]}',
+            'Content-Type': 'application/json'
+        }
+        del(data['api_key'])
+        response, errors = requests.post(url=self.base_url,
+                                         json=data,
+                                         headers=headers
+                                        )
+        return self.create_response(data, response, errors)

--- a/notifiers/providers/sendgrid.py
+++ b/notifiers/providers/sendgrid.py
@@ -2,6 +2,8 @@ from ..core import Provider, Response
 from ..utils import requests
 
 """A couple of helper functions to help build the schema"""
+
+
 def get_email_object(title: str) -> dict:
     """returns a pre-canned email object with a custom title"""
     return {
@@ -36,7 +38,6 @@ def get_from_object(duplicate: bool) -> dict:
             }
         ]
     }
-
 
 
 class SendGrid(Provider):
@@ -143,15 +144,17 @@ class SendGrid(Provider):
                         },
                         'substitutions': {
                             'type': 'object',
-                            'title': 'A collection of key/value pairs that will ' +
-                                     'be applied to the text and html parts of the email',
+                            'title': 'A collection of key/value pairs that ' +
+                                     'will be applied to the text and html' +
+                                     'parts of the email',
                             'maxProperties': 10000
                         },
                         'custom_args': {
                             'type': 'object',
                             'title': 'Values that are specific to this ' +
                                      'personalization that will be carried' +
-                                     ' along with the email and its activity data',
+                                     ' along with the email and its ' +
+                                     'activity data',
                             'maxProperties': 10000
                         },
                         'send_at': {
@@ -171,7 +174,9 @@ class SendGrid(Provider):
             },
             'from': get_from_object(False),
             'from_': get_from_object(True),
-            'reply_to': get_email_object('The "reply to" address of the email'),
+            'reply_to': get_email_object(
+                'The "reply to" address of the email'
+            ),
             'subject': {
                 'type': 'string',
                 'title': 'The global subject of the message',
@@ -279,7 +284,8 @@ class SendGrid(Provider):
             },
             'batch_id': {
                 'type': 'string',
-                'title': 'This ID represents a batch of emails to be sent at the same time.'
+                'title': 'This ID represents a batch of emails to be sent ' +
+                         'at the same time.'
             },
             'asm': {
                 'type': 'object',
@@ -350,7 +356,8 @@ class SendGrid(Provider):
                         'properties': {
                             'enable': {
                                 'type': 'boolean',
-                                'title': 'Indicates if this setting is enabled.'
+                                'title': 'Indicates if this setting is ' +
+                                         'enabled.'
                             }
                         }
                     },
@@ -362,7 +369,8 @@ class SendGrid(Provider):
                         'properties': {
                             'enable': {
                                 'type': 'boolean',
-                                'title': 'Indicates if this setting is enabled.'
+                                'title': 'Indicates if this setting is ' +
+                                         'enabled.'
                             },
                             'text': {
                                 'type': 'string',
@@ -376,17 +384,10 @@ class SendGrid(Provider):
                         }
                     },
                     'sandbox_mode': {
-                        'type': 'object',
-                        'additionalProperties': False,
+                        'type': 'boolean',
                         'title': 'This allows you to send a test email to ' +
                                  'ensure that your request body is valid ' +
                                  'and formatted correctly.',
-                        'properties': {
-                            'enable': {
-                                'type': 'boolean',
-                                'title': 'Indicates if this setting is enabled'
-                            }
-                        }
                     },
                     'spam_check': {
                         'type': 'object',
@@ -423,8 +424,8 @@ class SendGrid(Provider):
                 'type': 'object',
                 'additionalProperties': False,
                 'title': 'Settings to determine how you would like to ' +
-                         'track the metrics of how your recipients interact '+
-                         'with your email.',
+                         'track the metrics of how your recipients interact' +
+                         ' with your email.',
                 'properties': {
                     'click_tracking': {
                         'type': 'object',
@@ -461,7 +462,7 @@ class SendGrid(Provider):
                                          'insert in the body of your ' +
                                          'email at a location that you ' +
                                          'desire. This tag will be ' +
-                                         'replaced by the open tracking '+
+                                         'replaced by the open tracking ' +
                                          'pixel.'
                             }
                         }
@@ -496,13 +497,14 @@ class SendGrid(Provider):
                             },
                             'substitution_tag': {
                                 'type': 'string',
-                                'title': 'A tag that will be replaced with the ' +
-                                         'unsubscribe URL. for example: ' +
+                                'title': 'A tag that will be replaced with ' +
+                                         'the unsubscribe URL. for example: ' +
                                          '[unsubscribe_url]. If this ' +
-                                         'parameter is used, it will override' +
-                                         ' both the text and html parameters.' +
-                                         ' The URL of the link will be placed' +
-                                         ' at the substitution tag’s location' +
+                                         'parameter is used, it will ' +
+                                         'override both the text and' +
+                                         ' html parameters. The URL of ' +
+                                         'the link will be placed at ' +
+                                         'the substitution tag’s location' +
                                          ', with no additional formatting.'
                             }
                         }
@@ -516,7 +518,7 @@ class SendGrid(Provider):
                                  'would like to specify the location of the' +
                                  ' link within your email, you may use the ' +
                                  'substitution_tag.',
-                        'properties' : {
+                        'properties': {
                             'enable': {
                                 'type': 'boolean',
                                 'title': 'Indicates if this setting is enabled'
@@ -577,8 +579,7 @@ class SendGrid(Provider):
         # complicated about setting that
         if data.get('to'):
 
-            if not data.get('personalizations'):
-                data['personalizations'] = []
+            data.setdefault('personalizations', [])
 
             data['personalizations'].append(
                 {
@@ -590,17 +591,20 @@ class SendGrid(Provider):
                 }
             )
 
+        if 'mail_settings' in data and 'sandbox_mode' in data['mail_settings']:
+            data['mail_settings']['sandbox_mode'] = {
+                'enable': data['mail_settings'].pop('sandbox_mode')
+            }
 
         return data
 
     def _send_notification(self, data: dict) -> Response:
         headers = {
             'Authorization': f'Bearer {data["api_key"]}',
-            'Content-Type': 'application/json'
         }
         del data['api_key']
         response, errors = requests.post(url=self.base_url,
                                          json=data,
                                          headers=headers
-                                        )
+                                         )
         return self.create_response(data, response, errors)

--- a/notifiers/providers/sendgrid.py
+++ b/notifiers/providers/sendgrid.py
@@ -10,10 +10,7 @@ class SendGrid(Provider):
     base_url = 'https://api.sendgrid.com/v3/mail/send'
     site_url = 'https://sendgrid.com/docs'
     name = 'sendgrid'
-    # TODO what is this?
-    path_to_errors = 'message',
 
-    # TODO what is this? why do we specify the top level required seperately?
     _required = {
         'allOf': [
             {
@@ -111,8 +108,8 @@ class SendGrid(Provider):
         'properties': {
             'to': {
                 'type': 'string',
-                'title': 'The destination address of the email, will override' +
-                         ' and replace any provided personalizations',
+                'title': 'The destination address of the email, will' +
+                         ' be appended to the personalizations',
                 'format': 'email'
             },
             'api_key': {
@@ -178,7 +175,8 @@ class SendGrid(Provider):
                 'properties': {
                     'email': {
                         'type': 'string',
-                        'title': 'The email address'
+                        'title': 'The email address',
+                        'format': 'email'
                     },
                     'name': {
                         'type': 'string',
@@ -582,15 +580,18 @@ class SendGrid(Provider):
         # inserting support for a 'to' argument, since sendgrid is a little
         # complicated about setting that
         if data.get('to'):
-            data['personalizations'] = [
+            if not data.get('personalizations'):
+                data['personalizations'] = []
+
+            data['personalizations'].append(
                 {
                     'to': [
-                            {
-                                'email': data.pop('to')
-                            }
-                        ]
+                        {
+                            'email': data.pop('to')
+                        }
+                    ]
                 }
-            ]
+            )
 
 
         return data

--- a/notifiers/providers/sendgrid.py
+++ b/notifiers/providers/sendgrid.py
@@ -159,6 +159,7 @@ class SendGrid(Provider):
                         },
                         'send_at': {
                             'type': 'integer',
+                            'format': 'timestamp',
                             'title': 'A unix timestamp allowing you to ' +
                                      'specify when you want your email ' +
                                      'to be delivered',
@@ -291,6 +292,7 @@ class SendGrid(Provider):
             },
             'send_at': {
                 'type': 'integer',
+                'format': 'timestamp',
                 'title': 'A unix timestamp allowing you to specify when ' +
                          'you want your email to be delivered'
             },

--- a/notifiers/providers/sendgrid.py
+++ b/notifiers/providers/sendgrid.py
@@ -1,8 +1,5 @@
-import json
-
 from ..core import Provider, Response
 from ..utils import requests
-from ..utils.schema.helpers import one_or_more
 
 
 class SendGrid(Provider):
@@ -154,7 +151,7 @@ class SendGrid(Provider):
                         'send_at': {
                             'type': 'integer',
                             'title': 'A unix timestamp allowing you to ' +
-                                     'specify when you want your email ' + 
+                                     'specify when you want your email ' +
                                      'to be delivered',
                         }
 
@@ -185,81 +182,81 @@ class SendGrid(Provider):
                 }
             },
             'subject': {
-                    'type': 'string',
-                    'title': 'The global subject of the message',
-                    'minLength': 1
+                'type': 'string',
+                'title': 'The global subject of the message',
+                'minLength': 1
             },
             'content': {
-                    'type': 'array',
-                    'title': 'An array in which you may specify the content' +
-                             ' of your email by mime type',
-                    'items': {
-                        'additionalProperties': False,
-                        'required': ['type', 'value'],
-                        'properties': {
-                            'type': {
-                                'type': 'string',
-                                'minLength': 1,
-                                'title': 'The mime type of this message part' +
-                                         ' e.g "text/html"'
-                            },
-                            'value': {
-                                'type': 'string',
-                                'minLength': 1,
-                                'title': 'The actual content of the specified' +
-                                         ' mime type'
-                            }
+                'type': 'array',
+                'title': 'An array in which you may specify the content' +
+                         ' of your email by mime type',
+                'items': {
+                    'additionalProperties': False,
+                    'required': ['type', 'value'],
+                    'properties': {
+                        'type': {
+                            'type': 'string',
+                            'minLength': 1,
+                            'title': 'The mime type of this message part' +
+                                     ' e.g "text/html"'
+                        },
+                        'value': {
+                            'type': 'string',
+                            'minLength': 1,
+                            'title': 'The actual content of the specified' +
+                                     ' mime type'
                         }
                     }
-                },
+                }
+            },
             'attachments': {
-                    'type': 'array',
-                    'title': 'An array of attachments for your email',
-                    'items': {
-                        'additionalProperties': False,
-                        'required': ['content', 'filename'],
-                        'properties': {
-                            'content': {
-                                'type': 'string',
-                                'title': 'The base64 encoded content of the' +
-                                         ' attachment',
-                                'minLength': 1,
-                            },
-                            'type': {
-                                'type': 'string',
-                                'title': 'The mime type of the attachment',
-                                'minLength': 1
-                            },
-                            'filename': {
-                                'type': 'string',
-                                'title': 'The filename of the attachment',
-                                'minLength': 1
-                            },
-                            'disposition': {
-                                'type': 'string',
-                                'default': 'attachment',
-                                'enum': [
-                                    'inline',
-                                    'attachment'
-                                ]
-                            },
-                            'content_id': {
-                                'type': 'string',
-                                'title': 'the content ID for the attachment' +
-                                         ', used when disposition is ' +
-                                          '"inline"',
-                            }
+                'type': 'array',
+                'title': 'An array of attachments for your email',
+                'items': {
+                    'additionalProperties': False,
+                    'required': ['content', 'filename'],
+                    'properties': {
+                        'content': {
+                            'type': 'string',
+                            'title': 'The base64 encoded content of the' +
+                                     ' attachment',
+                            'minLength': 1,
+                        },
+                        'type': {
+                            'type': 'string',
+                            'title': 'The mime type of the attachment',
+                            'minLength': 1
+                        },
+                        'filename': {
+                            'type': 'string',
+                            'title': 'The filename of the attachment',
+                            'minLength': 1
+                        },
+                        'disposition': {
+                            'type': 'string',
+                            'default': 'attachment',
+                            'enum': [
+                                'inline',
+                                'attachment'
+                            ]
+                        },
+                        'content_id': {
+                            'type': 'string',
+                            'title': 'the content ID for the attachment' +
+                                     ', used when disposition is ' +
+                                     '"inline"',
                         }
                     }
+                }
             },
             'template_id': {
-                    'type': 'string',
-                    'title': 'The ID of the template you would like to use'
+                'type': 'string',
+                'title': 'The ID of the template you would like to use'
             },
             'sections': {
-                    'type': 'object',
-                    'title': 'An object of key/value pairs that define ' +
-                            'block sections to be used for substitutions'
+                'type': 'object',
+                'title': 'An object of key/value pairs that define ' +
+                         'block sections to be used for substitutions'
             },
             'headers': {
                 'type': 'object',
@@ -307,9 +304,9 @@ class SendGrid(Provider):
                     'groups_to_display': {
                         'type': 'array',
                         'title': 'An array containing the unsubscribe ' +
-                                 'groups that you would like to be' + 
-                                ' displayed on the unsubscribe preferences' + 
-                                ' page.',
+                                 'groups that you would like to be' +
+                                 ' displayed on the unsubscribe preferences' +
+                                 ' page.',
                         'maxItems': 25,
                         'items': {
                             'type': 'integer'
@@ -354,7 +351,7 @@ class SendGrid(Provider):
                     'bypass_list_management': {
                         'type': 'object',
                         'additionalProperties': False,
-                        'title': 'Allows you to bypass all unsubscribe ' + 
+                        'title': 'Allows you to bypass all unsubscribe ' +
                                  'groups and suppressions to ensure that ' +
                                  'the email is delivered to every single ' +
                                  'recipient.',
@@ -550,7 +547,7 @@ class SendGrid(Provider):
                             'utm_content': {
                                 'type': 'string',
                                 'title': 'Used to differentiate your ' +
-                                         'campaign from advertisements.'  
+                                         'campaign from advertisements.'
                             },
                             'utm_campaign': {
                                 'type': 'string',
@@ -601,7 +598,7 @@ class SendGrid(Provider):
             'Authorization': f'Bearer {data["api_key"]}',
             'Content-Type': 'application/json'
         }
-        del(data['api_key'])
+        del data['api_key']
         response, errors = requests.post(url=self.base_url,
                                          json=data,
                                          headers=headers

--- a/notifiers/providers/sendgrid.py
+++ b/notifiers/providers/sendgrid.py
@@ -84,20 +84,29 @@ class SendGrid(Provider):
     }
 
     __from = {
-        'type': 'object',
-        'title': 'The from address of the email',
-        'additionalProperties': False,
-        'required': ['email'],
-        'properties': {
-            'email': {
-                'type': 'string',
-                'title': 'The email address'
+        'oneOf': [
+            {
+                'type': 'object',
+                'title': 'The from address of the email',
+                'additionalProperties': False,
+                'required': ['email'],
+                'properties': {
+                    'email': {
+                        'type': 'string',
+                        'title': 'The email address'
+                    },
+                    'name': {
+                        'type': 'string',
+                        'title': 'The name associated with the email address'
+                    }
+                }
             },
-            'name': {
+            {
                 'type': 'string',
-                'title': 'The name associated with the email address'
+                'title': 'the email address to set in the "from" headers',
+                'format': 'email'
             }
-        }
+        ]
     }
 
     _schema = {
@@ -564,6 +573,10 @@ class SendGrid(Provider):
     def _prepare_data(self, data: dict) -> dict:
         if data.get('from_'):
             data['from'] = data.pop('from_')
+        if isinstance(data['from'], str):
+            data['from'] = {
+                'email': data.pop('from')
+            }
 
         if data.get('message'):
             content = [

--- a/notifiers/providers/sendgrid.py
+++ b/notifiers/providers/sendgrid.py
@@ -573,6 +573,9 @@ class SendGrid(Provider):
     def _prepare_data(self, data: dict) -> dict:
         if data.get('from_'):
             data['from'] = data.pop('from_')
+
+        # supporting a bare string 'from', this simplifies
+        # the API and allows us to use the CLI
         if isinstance(data['from'], str):
             data['from'] = {
                 'email': data.pop('from')
@@ -590,6 +593,7 @@ class SendGrid(Provider):
         # inserting support for a 'to' argument, since sendgrid is a little
         # complicated about setting that
         if data.get('to'):
+
             if not data.get('personalizations'):
                 data['personalizations'] = []
 

--- a/notifiers/providers/sendgrid.py
+++ b/notifiers/providers/sendgrid.py
@@ -1,6 +1,43 @@
 from ..core import Provider, Response
 from ..utils import requests
 
+"""A couple of helper functions to help build the schema"""
+def get_email_object(title: str) -> dict:
+    """returns a pre-canned email object with a custom title"""
+    return {
+        'type': 'object',
+        'title': title,
+        'additionalProperties': False,
+        'required': ['email'],
+        'properties': {
+            'email': {
+                'type': 'string',
+                'title': 'The email address of the recipient',
+                'format': 'email'
+            },
+            'name': {
+                'type': 'string',
+                'title': 'The name associated with the email address'
+            }
+        }
+    }
+
+
+def get_from_object(duplicate: bool) -> dict:
+    """returns a pre-canned 'from' schema, optionally labeled a dupe"""
+    return {
+        'duplicate': duplicate,
+        'oneOf': [
+            get_email_object('The from address of the email'),
+            {
+                'type': 'string',
+                'title': 'The from address of the email',
+                'format': 'email'
+            }
+        ]
+    }
+
+
 
 class SendGrid(Provider):
     """Send emails via SendGrid"""
@@ -66,47 +103,7 @@ class SendGrid(Provider):
         'minItems': 1,
         'maxItems': 1000,
         'uniqueItems': False,
-        'items': {
-            'type': 'object',
-            'required': ['email'],
-            'properties': {
-                'email': {
-                    'type': 'string',
-                    'title': 'Email address of recipient',
-                    'format': 'email'
-                },
-                'name': {
-                    'type': 'string',
-                    'title': 'Name of recipient'
-                }
-            }
-        }
-    }
-
-    __from = {
-        'oneOf': [
-            {
-                'type': 'object',
-                'title': 'The from address of the email',
-                'additionalProperties': False,
-                'required': ['email'],
-                'properties': {
-                    'email': {
-                        'type': 'string',
-                        'title': 'The email address'
-                    },
-                    'name': {
-                        'type': 'string',
-                        'title': 'The name associated with the email address'
-                    }
-                }
-            },
-            {
-                'type': 'string',
-                'title': 'the email address to set in the "from" headers',
-                'format': 'email'
-            }
-        ]
+        'items': get_email_object('A recipient address')
     }
 
     _schema = {
@@ -172,25 +169,9 @@ class SendGrid(Provider):
                 'type': 'string',
                 'title': 'Plain text message content'
             },
-            'from': __from,
-            'from_': __from,
-            'reply_to': {
-                'type': 'object',
-                'title': 'The "reply to" address of the email',
-                'additionalProperties': False,
-                'required': ['email'],
-                'properties': {
-                    'email': {
-                        'type': 'string',
-                        'title': 'The email address',
-                        'format': 'email'
-                    },
-                    'name': {
-                        'type': 'string',
-                        'title': 'The name associated with the email address'
-                    }
-                }
-            },
+            'from': get_from_object(False),
+            'from_': get_from_object(True),
+            'reply_to': get_email_object('The "reply to" address of the email'),
             'subject': {
                 'type': 'string',
                 'title': 'The global subject of the message',

--- a/notifiers/utils/schema/formats.py
+++ b/notifiers/utils/schema/formats.py
@@ -56,7 +56,7 @@ def is_valid_port(instance: int):
     return int(instance) in range(65535)
 
 
-@format_checker.checks('timestamp', raises=ValueError)
+@format_checker.checks('timestamp', raises=(ValueError, OverflowError, OSError))
 def is_timestamp(instance):
     if not isinstance(instance, (int, str)):
         return True

--- a/tests/providers/test_sendgrid.py
+++ b/tests/providers/test_sendgrid.py
@@ -397,9 +397,15 @@ class TestSendgridSchema:
         payload['custom_args'] = {'key': 'value'}
         assert provider._process_data(**payload) == payload
 
-    def test_send_at(self, provider):
+    def test_send_at_invalid_timestamp(self, provider):
         payload = get_basic_payload()
-        payload['send_at'] = 1234
+        payload['send_at'] = 9999999999999999
+        with pytest.raises(BadArguments, match=" 9999999999999999 is not a 'timestamp'"):
+            provider._process_data(**payload)
+
+    def test_send_at_valid(self, provider):
+        payload = get_basic_payload()
+        payload['send_at'] = 1534297539
         assert provider._process_data(**payload) == payload
 
     def test_batch_id(self, provider):

--- a/tests/providers/test_sendgrid.py
+++ b/tests/providers/test_sendgrid.py
@@ -6,13 +6,12 @@ Online functional tests require the following env variables:
 The 'from' email in the online tests will be 'test@example.com'
 """
 # pylint: disable=too-many-public-methods,no-self-use,redefined-outer-name
-# pylint: disable=protected-access,missing-docstring,invalid-name
+# pylint: disable=missing-docstring,invalid-name
 import os
-import re
 import copy
 import base64
-import pytest
 from unittest.mock import MagicMock
+import pytest
 from notifiers.exceptions import BadArguments
 provider = 'sendgrid'
 
@@ -68,23 +67,10 @@ class TestSendgridSchema:
             return MagicMock(), []
         monkeypatch.setattr('notifiers.utils.requests.post', requests_return)
 
-    old_environ = {}
-
-    @classmethod
-    def setup_class(cls):
-        """
-        deleting all the NOTIFIERS variables before the schema tests
-        so we can interact purely with the test data in this class
-        """
-        for each in os.environ:
-            if re.match('^NOTIFIERS.*', each):
-                cls.old_environ[each] = os.environ.pop(each)
-
-    @classmethod
-    def teardown_class(cls):
-        """put the NOTIFIERS variables back for other tests"""
-        for each in cls.old_environ:
-            os.environ[each] = cls.old_environ[each]
+    @pytest.fixture(autouse=True)
+    def patch_environment(self, monkeypatch):
+        monkeypatch.delenv('NOTIFIERS_SENDGRID_TO', raising=False)
+        monkeypatch.delenv('NOTIFIERS_SENDGRID_API_KEY', raising=False)
 
     def test_sendgrid_metadata(self, provider):
         assert(provider.metadata == {
@@ -94,7 +80,7 @@ class TestSendgridSchema:
         })
 
     def test_basic_payload(self, provider):
-        rsp = provider.notify(**get_basic_payload())
+        provider.notify(**get_basic_payload())
 
     to_payloads = [
         (

--- a/tests/providers/test_sendgrid.py
+++ b/tests/providers/test_sendgrid.py
@@ -1,0 +1,507 @@
+import pytest
+import os
+import re
+from notifiers.exceptions import BadArguments
+provider = 'sendgrid'
+"""
+Collection of unit and functional tests for the sendgrid library.
+Online functional tests require the following env variables:
+    NOTIFIERS_SENDGRID_API_KEY
+    NOTIFIERS_SENDGRID_TO
+The 'from' email in the online tests will be 'test@example.com'
+"""
+
+def get_basic_payload():
+    """
+    gets a payload with the minimum required arguments, can be updated
+    with test data to test specific attributes in the payload without
+    having to worry about required arguments
+    """
+    return {
+        'personalizations': [
+            {
+                'to': [
+                        {
+                            'email': 'test@example.com'
+                        }
+                    ]
+            }
+        ],
+        'from': {
+            'email': 'test@example.com'
+        },
+        'subject': 'a friendly subject',
+        'content': [
+            {
+                'type': 'text/plain',
+                'value': 'my email content'
+            }
+        ],
+    }
+
+def get_attachment_payload():
+    payload = get_basic_payload()
+    payload['attachments'] = [
+        {
+            'content': 'my content',
+            'filename': 'my file name'
+        }
+    ]
+    return payload
+
+# deleting all the NOTIFIERS variables before the schema tests
+# so we can interact purely with the test data in this class
+@pytest.fixture()
+def clean_environment():
+    for each in os.environ:
+        if re.match('^NOTIFIERS.*', each):
+            del(os.environ[each])
+
+@pytest.mark.usefixtures('clean_environment')
+class TestSendgridSchema:
+
+    def test_sendgrid_metadata(self, provider):
+        assert(provider.metadata == {
+            'base_url': 'https://api.sendgrid.com/v3/mail/send',
+            'site_url': 'https://sendgrid.com/docs',
+            'name': 'sendgrid',
+        })
+
+
+    def test_basic_payload(self, provider):
+        provider._process_data(**get_basic_payload())
+
+    to_payloads = [
+        (
+            {
+                'personalizations': [
+                    {
+                        'to': 'someone'
+                    }
+                ]
+            },
+            "Error with sent data: 'someone' is not of type 'array'"
+        ),
+        (
+            {
+            'personalizations': [
+                    {
+                        'to': [
+                            {
+                                'name': 'someone'
+                            }
+                        ]
+                    }
+                ]
+            },
+            "Error with sent data: 'email' is a required property"
+        ),
+        (
+            {
+            'personalizations': [
+                    {
+                        'to': [
+                            {
+                                'email': 'test@example.com',
+                                'name': 'someone'
+                            },
+                            {
+                                'name': 'someone'
+                            }
+                        ]
+                    }
+                ]
+            },
+            "Error with sent data: 'email' is a required property"
+        ),
+        (
+            {
+                'personalizations': [
+                   {
+                       'to': [
+                            {
+                               'email': 'someone'
+                            }
+                        ]
+                    }
+                ]
+            },
+            "'someone' is not a 'email'"
+        )
+    ]
+    @pytest.mark.parametrize('payload,error', to_payloads)
+    def test_bad_personalization_to_values(self, payload, error, provider):
+        full_payload = get_basic_payload()
+        full_payload.update(payload)
+        with pytest.raises(BadArguments, match=error):
+            provider._validate_data(full_payload)
+
+    def test_personalization_multiple_to(self, provider):
+        payload = get_basic_payload()
+        payload.update({
+                    'personalizations': [
+                        {
+                            'to': [
+                                    {
+                                        'email': 'test@example.com',
+                                        'name': 'testing guy'
+                                    },
+                                    {
+                                        'email': 'test@example.com',
+                                        'name': 'testing guy'
+                                    }
+                            ]
+                        }
+                    ]
+                })
+        assert(provider._process_data(**payload) == payload)
+
+    def test_personalization_simple_cc_and_bcc(self, provider):
+        payload = get_basic_payload()
+        payload.update({
+                    'personalizations': [
+                        {
+                            'to': [
+                                    {
+                                        'email': 'test@example.com',
+                                        'name': 'testing guy'
+                                    },
+                            ],
+                            'cc': [
+                                    {
+                                        'email': 'test@example.com',
+                                        'name': 'testing guy'
+                                    }
+                            ],
+                            'bcc': [
+                                    {
+                                        'email': 'test@example.com',
+                                        'name': 'testing guy'
+                                    }
+                            ]
+                        }
+                    ]
+                })
+        assert(provider._process_data(**payload) == payload)
+
+    def test_personalization_headers(self, provider):
+        payload = get_basic_payload()
+        payload['personalizations'][0]['headers'] = {'X-Whatever': 'Value'}
+        assert(provider._process_data(**payload) == payload)
+
+    def test_personalization_subject(self, provider):
+        payload = get_basic_payload()
+        payload['personalizations'][0]['subject'] = 'my subject'
+        assert(provider._process_data(**payload) == payload)
+
+    def test_personalization_substitutions(self, provider):
+        payload = get_basic_payload()
+        payload['personalizations'][0]['substitutions'] = {'key': 'value'}
+        assert(provider._process_data(**payload) == payload)
+
+    def test_personalization_custom_args(self, provider):
+        payload = get_basic_payload()
+        payload['personalizations'][0]['custom_args'] = {'key': 'value'}
+        assert(provider._process_data(**payload) == payload)
+
+    def test_addtional_properties_in_personalizations(self, provider):
+        payload = get_basic_payload()
+        payload['personalizations'][0]['bad_data'] = 1234
+        with pytest.raises(BadArguments, match="'bad_data' was unexpected"):
+            provider._process_data(**payload)
+
+    def test_multiple_personalizations(self, provider):
+        payload = get_basic_payload()
+        payload['personalizations'].append(payload['personalizations'][0])
+        assert(provider._process_data(**payload) == payload)
+
+    def test_from_missing(self, provider):
+        payload = get_basic_payload()
+        del(payload['from'])
+        with pytest.raises(BadArguments, match="'from' is a required property"):
+            provider._process_data(**payload)
+
+    def test_from_email_missing(self, provider):
+        payload = get_basic_payload()
+        del(payload['from']['email'])
+        with pytest.raises(BadArguments, match="'email' is a required property"):
+            provider._process_data(**payload)
+
+    def test_from_name(self, provider):
+        payload = get_basic_payload()
+        payload['from']['name'] = 'bill'
+        assert(provider._process_data(**payload) == payload)
+
+    def test_from_additional_properties(self, provider):
+        payload = get_basic_payload()
+        payload['from']['bad_data'] = 1234
+        with pytest.raises(BadArguments, match="'bad_data' was unexpected"):
+            provider._process_data(**payload)
+
+    def test_reply_to_email_missing(self, provider):
+        payload = get_basic_payload()
+        payload['reply_to'] = {}
+        with pytest.raises(BadArguments, match="'email' is a required property"):
+            provider._process_data(**payload)
+
+    def test_email_name(self, provider):
+        payload = get_basic_payload()
+        payload['reply_to'] = {'name': 'bill', 'email': 'test@example.com'}
+        assert(provider._process_data(**payload) == payload)
+
+    def test_reply_to_additional_properties(self, provider):
+        payload = get_basic_payload()
+        payload['reply_to'] = {'bad_data': 1234}
+        with pytest.raises(BadArguments, match="'bad_data' was unexpected"):
+            provider._process_data(**payload)
+
+    def test_subject_missing(self, provider):
+        payload = get_basic_payload()
+        del(payload['subject'])
+        with pytest.raises(BadArguments, match="'subject' is a required property"):
+            provider._process_data(**payload)
+
+    def test_empty_subject(self, provider):
+        payload = get_basic_payload()
+        payload['subject'] = ''
+        with pytest.raises(BadArguments, match="'' is too short"):
+            provider._process_data(**payload)
+
+    def test_no_content(self, provider):
+        payload = get_basic_payload()
+        del(payload['content'])
+        with pytest.raises(BadArguments, match="'content' is a required property"):
+            provider._process_data(**payload)
+
+    def test_missing_mime_type(self, provider):
+        payload = get_basic_payload()
+        del(payload['content'][0]['type'])
+        with pytest.raises(BadArguments, match="'type' is a required property"):
+            provider._process_data(**payload)
+
+    def test_missing_content_value(self, provider):
+        payload = get_basic_payload()
+        del(payload['content'][0]['value'])
+        with pytest.raises(BadArguments, match="'value' is a required property"):
+            provider._process_data(**payload)
+
+    def test_empty_mime_type(self, provider):
+        payload = get_basic_payload()
+        payload['content'][0]['type'] = ''
+        with pytest.raises(BadArguments, match="'' is too short"):
+            provider._process_data(**payload)
+
+    def test_empty_content_value(self, provider):
+        payload = get_basic_payload()
+        payload['content'][0]['value'] = ''
+        with pytest.raises(BadArguments, match="'' is too short"):
+            provider._process_data(**payload)
+
+    def test_basic_attachment_payload(self, provider):
+        payload = get_attachment_payload()
+        assert(provider._process_data(**payload) == payload)
+
+    def test_attachment_content_missing(self, provider):
+        payload = get_attachment_payload()
+        del(payload['attachments'][0]['content'])
+        with pytest.raises(BadArguments, match="'content' is a required property"):
+            provider._process_data(**payload)
+
+    def test_attachment_filename_missing(self, provider):
+        payload = get_attachment_payload()
+        del(payload['attachments'][0]['filename'])
+        with pytest.raises(BadArguments, match="'filename' is a required property"):
+            provider._process_data(**payload)
+
+    def test_empty_attachment_content(self, provider):
+        payload = get_attachment_payload()
+        payload['attachments'][0]['content'] = ''
+        with pytest.raises(BadArguments, match="'' is too short"):
+            provider._process_data(**payload)
+
+    def test_empty_attachment_filename(self, provider):
+        payload = get_attachment_payload()
+        payload['attachments'][0]['filename'] = ''
+        with pytest.raises(BadArguments, match="'' is too short"):
+            provider._process_data(**payload)
+
+    def test_attachment_extra_properties(self, provider):
+        payload = get_attachment_payload()
+        payload['attachments'][0]['bad_data'] = 1234
+        with pytest.raises(BadArguments, match="'bad_data' was unexpected"):
+            provider._process_data(**payload)
+
+    def test_attachment_disposition_inline(self, provider):
+        payload = get_attachment_payload()
+        payload['attachments'][0]['disposition'] = 'inline'
+        assert(provider._process_data(**payload) == payload)
+
+    def test_attachment_disposition_attachment(self, provider):
+        payload = get_attachment_payload()
+        payload['attachments'][0]['disposition'] = 'attachment'
+        assert(provider._process_data(**payload) == payload)
+
+    def test_attachment_bad_disposition(self, provider):
+        payload = get_attachment_payload()
+        payload['attachments'][0]['disposition'] = 'bad_data'
+        with pytest.raises(BadArguments, match="'bad_data' is not one of"):
+            provider._process_data(**payload)
+
+    def test_attachment_content_id(self, provider):
+        payload = get_attachment_payload()
+        payload['attachments'][0]['content_id'] = 'string'
+        assert(provider._process_data(**payload) == payload)
+
+    def test_template_id(self, provider):
+        payload = get_basic_payload()
+        payload['template_id'] = 'string'
+        assert(provider._process_data(**payload) == payload)
+
+    def test_sections(self, provider):
+        payload = get_basic_payload()
+        payload['sections'] = {'key': 'value', 'key2': 'value'}
+        assert(provider._process_data(**payload) == payload)
+
+    def test_headers(self, provider):
+        payload = get_basic_payload()
+        payload['headers'] = {'key': 'value', 'key2': 'value'}
+        assert(provider._process_data(**payload) == payload)
+    
+    def test_categories(self, provider):
+        payload = get_basic_payload()
+        payload['categories'] = ['a', 'b', 'c']
+        assert(provider._process_data(**payload) == payload)
+
+    def test_non_unique_categories(self, provider):
+        payload = get_basic_payload()
+        payload['categories'] = ['a', 'a', 'a']
+        with pytest.raises(BadArguments, match="has non-unique elements"):
+            provider._process_data(**payload)
+
+    def test_custom_args(self, provider):
+        payload = get_basic_payload()
+        payload['custom_args'] = {'key': 'value'}
+        assert(provider._process_data(**payload) == payload)
+
+    def test_send_at(self, provider):
+        payload = get_basic_payload()
+        payload['send_at'] = 1234
+        assert(provider._process_data(**payload) == payload)
+
+    def test_batch_id(self, provider):
+        payload = get_basic_payload()
+        payload['batch_id'] = 'batch id'
+        assert(provider._process_data(**payload) == payload)
+
+    def test_asm(self, provider):
+        payload = get_basic_payload()
+        payload['asm'] = {
+            'group_id': 1234,
+            'groups_to_display': [1,2,3]
+        }
+        assert(provider._process_data(**payload) == payload)
+
+    def test_asm_no_group_id(self, provider):
+        payload = get_basic_payload()
+        payload['asm'] = {}
+        with pytest.raises(BadArguments, match="'group_id' is a required property"):
+            provider._process_data(**payload)
+
+    def test_asm_additional_properties(self, provider):
+        payload = get_basic_payload()
+        payload['asm'] = {
+            'group_id': 1234,
+            'bad_data': 1
+        }
+        with pytest.raises(BadArguments, match="'bad_data' was unexpected"):
+            provider._process_data(**payload)
+
+    def test_ip_pool_name(self, provider):
+        payload = get_basic_payload()
+        payload['ip_pool_name'] = 'asdf'
+        assert(provider._process_data(**payload) == payload)
+
+    def test_mail_settings(self, provider):
+        payload = get_basic_payload()
+        payload['mail_settings'] = {
+            'bcc': {
+                'enable': True,
+                'email': 'someone@example.com'
+            },
+            'bypass_list_management': {
+                'enable': True,
+            },
+            'footer': {
+                'enable': True,
+                'text': 'some text',
+                'html': '<h1>some html</h1>'
+            },
+            'sandbox_mode': {
+                'enable': True,
+            },
+            'spam_check': {
+                'enable': True,
+                'threshold': 10,
+                'post_to_url': 'http://foo.com'
+            }
+        }
+        assert(provider._process_data(**payload) == payload)
+
+    def test_tracking_settings(self, provider):
+        payload = get_basic_payload()
+        payload['tracking_settings'] = {
+            'click_tracking': {
+                'enable': True,
+                'enable_text': True
+            },
+            'subscription_tracking': {
+                'enable': True,
+                'text': 'asdf',
+                'html': '<h1>asdf</h1>',
+                'substitution_tag': '[tag]'
+            },
+            'ganalytics': {
+                'enable': True,
+                'utm_source': 'something',
+                'utm_medium': 'something',
+                'utm_term': 'something',
+                'utm_content': 'something',
+                'utm_campaign': 'something'
+            }
+        }
+        assert(provider._process_data(**payload) == payload)
+
+class TestSendgridProviderOverrides:
+    def test_from_(self, provider):
+        payload = get_basic_payload()
+        payload['from_'] = payload.pop('from')
+        assert(provider._process_data(**payload) == get_basic_payload())
+
+    def test_message(self, provider):
+        payload = get_basic_payload()
+        payload['message'] = payload['content'][0]['value']
+        del(payload['content'])
+        assert(provider._process_data(**payload) == get_basic_payload())
+
+    def test_to(self, provider):
+        payload = get_basic_payload()
+        payload['to'] = payload['personalizations'][0]['to'][0]['email']
+        del(payload['personalizations'])
+        assert(provider._process_data(**payload) == get_basic_payload())
+
+def get_online_basic_payload():
+    """
+    Gets a basic payload with the live variables deleted, so that
+    they can only be set on the command line
+    """
+    payload = get_basic_payload()
+    # delete this so that the 'to' from the environment gets read in instead
+    del(payload['personalizations'])
+    return payload
+
+class TestSendgridOnline:
+
+    @pytest.mark.online
+    def test_basic(self, provider):
+        payload = get_online_basic_payload()
+        provider.notify(**payload, raise_on_errors=True)

--- a/tests/providers/test_sendgrid.py
+++ b/tests/providers/test_sendgrid.py
@@ -1,9 +1,3 @@
-import os
-import re
-import base64
-import pytest
-from notifiers.exceptions import BadArguments
-provider = 'sendgrid'
 """
 Collection of unit and functional tests for the sendgrid library.
 Online functional tests require the following env variables:
@@ -11,6 +5,14 @@ Online functional tests require the following env variables:
     NOTIFIERS_SENDGRID_TO
 The 'from' email in the online tests will be 'test@example.com'
 """
+# pylint: disable=too-many-public-methods,no-self-use,redefined-outer-name,missing-docstring
+# pylint: disable=protected-access
+import os
+import re
+import base64
+import pytest
+from notifiers.exceptions import BadArguments
+provider = 'sendgrid'
 
 def get_basic_payload():
     """
@@ -22,10 +24,10 @@ def get_basic_payload():
         'personalizations': [
             {
                 'to': [
-                        {
-                            'email': 'test@example.com'
-                        }
-                    ]
+                    {
+                        'email': 'test@example.com'
+                    }
+                ]
             }
         ],
         'from': {
@@ -41,6 +43,7 @@ def get_basic_payload():
     }
 
 def get_attachment_payload():
+    """Gets a payload section for attachments"""
     payload = get_basic_payload()
     payload['attachments'] = [
         {
@@ -51,7 +54,7 @@ def get_attachment_payload():
     return payload
 
 class TestSendgridSchema:
-
+    """Tests just the schema validation for SG"""
     old_environ = {}
 
     @classmethod
@@ -67,7 +70,7 @@ class TestSendgridSchema:
     @classmethod
     def teardown_class(cls):
         """put the NOTIFIERS variables back for other tests"""
-        print (cls.old_environ)
+        print(cls.old_environ)
         for each in cls.old_environ:
             os.environ[each] = cls.old_environ[each]
 
@@ -95,7 +98,7 @@ class TestSendgridSchema:
         ),
         (
             {
-            'personalizations': [
+                'personalizations': [
                     {
                         'to': [
                             {
@@ -109,7 +112,7 @@ class TestSendgridSchema:
         ),
         (
             {
-            'personalizations': [
+                'personalizations': [
                     {
                         'to': [
                             {
@@ -128,10 +131,10 @@ class TestSendgridSchema:
         (
             {
                 'personalizations': [
-                   {
-                       'to': [
+                    {
+                        'to': [
                             {
-                               'email': 'someone'
+                                'email': 'someone'
                             }
                         ]
                     }
@@ -150,70 +153,70 @@ class TestSendgridSchema:
     def test_personalization_multiple_to(self, provider):
         payload = get_basic_payload()
         payload.update({
-                    'personalizations': [
+            'personalizations': [
+                {
+                    'to': [
                         {
-                            'to': [
-                                    {
-                                        'email': 'test@example.com',
-                                        'name': 'testing guy'
-                                    },
-                                    {
-                                        'email': 'test@example.com',
-                                        'name': 'testing guy'
-                                    }
-                            ]
+                            'email': 'test@example.com',
+                            'name': 'testing guy'
+                        },
+                        {
+                            'email': 'test@example.com',
+                            'name': 'testing guy'
                         }
                     ]
-                })
-        assert(provider._process_data(**payload) == payload)
+                }
+            ]
+        })
+        assert provider._process_data(**payload) == payload
 
     def test_personalization_simple_cc_and_bcc(self, provider):
         payload = get_basic_payload()
         payload.update({
-                    'personalizations': [
+            'personalizations': [
+                {
+                    'to': [
                         {
-                            'to': [
-                                    {
-                                        'email': 'test@example.com',
-                                        'name': 'testing guy'
-                                    },
-                            ],
-                            'cc': [
-                                    {
-                                        'email': 'test@example.com',
-                                        'name': 'testing guy'
-                                    }
-                            ],
-                            'bcc': [
-                                    {
-                                        'email': 'test@example.com',
-                                        'name': 'testing guy'
-                                    }
-                            ]
+                            'email': 'test@example.com',
+                            'name': 'testing guy'
+                        },
+                    ],
+                    'cc': [
+                        {
+                            'email': 'test@example.com',
+                            'name': 'testing guy'
+                        }
+                    ],
+                    'bcc': [
+                        {
+                            'email': 'test@example.com',
+                            'name': 'testing guy'
                         }
                     ]
-                })
-        assert(provider._process_data(**payload) == payload)
+                }
+            ]
+        })
+        assert provider._process_data(**payload) == payload
 
     def test_personalization_headers(self, provider):
         payload = get_basic_payload()
         payload['personalizations'][0]['headers'] = {'X-Whatever': 'Value'}
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_personalization_subject(self, provider):
         payload = get_basic_payload()
         payload['personalizations'][0]['subject'] = 'my subject'
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_personalization_substitutions(self, provider):
         payload = get_basic_payload()
         payload['personalizations'][0]['substitutions'] = {'key': 'value'}
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_personalization_custom_args(self, provider):
         payload = get_basic_payload()
         payload['personalizations'][0]['custom_args'] = {'key': 'value'}
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_addtional_properties_in_personalizations(self, provider):
         payload = get_basic_payload()
@@ -224,24 +227,24 @@ class TestSendgridSchema:
     def test_multiple_personalizations(self, provider):
         payload = get_basic_payload()
         payload['personalizations'].append(payload['personalizations'][0])
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_from_missing(self, provider):
         payload = get_basic_payload()
-        del(payload['from'])
+        del payload['from']
         with pytest.raises(BadArguments, match="'from' is a required property"):
             provider._process_data(**payload)
 
     def test_from_email_missing(self, provider):
         payload = get_basic_payload()
-        del(payload['from']['email'])
+        del payload['from']['email']
         with pytest.raises(BadArguments, match="'email' is a required property"):
             provider._process_data(**payload)
 
     def test_from_name(self, provider):
         payload = get_basic_payload()
         payload['from']['name'] = 'bill'
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_from_additional_properties(self, provider):
         payload = get_basic_payload()
@@ -258,7 +261,7 @@ class TestSendgridSchema:
     def test_email_name(self, provider):
         payload = get_basic_payload()
         payload['reply_to'] = {'name': 'bill', 'email': 'test@example.com'}
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_reply_to_additional_properties(self, provider):
         payload = get_basic_payload()
@@ -268,7 +271,7 @@ class TestSendgridSchema:
 
     def test_subject_missing(self, provider):
         payload = get_basic_payload()
-        del(payload['subject'])
+        del payload['subject']
         with pytest.raises(BadArguments, match="'subject' is a required property"):
             provider._process_data(**payload)
 
@@ -280,19 +283,19 @@ class TestSendgridSchema:
 
     def test_no_content(self, provider):
         payload = get_basic_payload()
-        del(payload['content'])
+        del payload['content']
         with pytest.raises(BadArguments, match="'content' is a required property"):
             provider._process_data(**payload)
 
     def test_missing_mime_type(self, provider):
         payload = get_basic_payload()
-        del(payload['content'][0]['type'])
+        del payload['content'][0]['type']
         with pytest.raises(BadArguments, match="'type' is a required property"):
             provider._process_data(**payload)
 
     def test_missing_content_value(self, provider):
         payload = get_basic_payload()
-        del(payload['content'][0]['value'])
+        del payload['content'][0]['value']
         with pytest.raises(BadArguments, match="'value' is a required property"):
             provider._process_data(**payload)
 
@@ -310,17 +313,17 @@ class TestSendgridSchema:
 
     def test_basic_attachment_payload(self, provider):
         payload = get_attachment_payload()
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_attachment_content_missing(self, provider):
         payload = get_attachment_payload()
-        del(payload['attachments'][0]['content'])
+        del payload['attachments'][0]['content']
         with pytest.raises(BadArguments, match="'content' is a required property"):
             provider._process_data(**payload)
 
     def test_attachment_filename_missing(self, provider):
         payload = get_attachment_payload()
-        del(payload['attachments'][0]['filename'])
+        del payload['attachments'][0]['filename']
         with pytest.raises(BadArguments, match="'filename' is a required property"):
             provider._process_data(**payload)
 
@@ -345,12 +348,12 @@ class TestSendgridSchema:
     def test_attachment_disposition_inline(self, provider):
         payload = get_attachment_payload()
         payload['attachments'][0]['disposition'] = 'inline'
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_attachment_disposition_attachment(self, provider):
         payload = get_attachment_payload()
         payload['attachments'][0]['disposition'] = 'attachment'
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_attachment_bad_disposition(self, provider):
         payload = get_attachment_payload()
@@ -361,27 +364,27 @@ class TestSendgridSchema:
     def test_attachment_content_id(self, provider):
         payload = get_attachment_payload()
         payload['attachments'][0]['content_id'] = 'string'
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_template_id(self, provider):
         payload = get_basic_payload()
         payload['template_id'] = 'string'
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_sections(self, provider):
         payload = get_basic_payload()
         payload['sections'] = {'key': 'value', 'key2': 'value'}
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_headers(self, provider):
         payload = get_basic_payload()
         payload['headers'] = {'key': 'value', 'key2': 'value'}
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_categories(self, provider):
         payload = get_basic_payload()
         payload['categories'] = ['a', 'b', 'c']
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_non_unique_categories(self, provider):
         payload = get_basic_payload()
@@ -392,25 +395,25 @@ class TestSendgridSchema:
     def test_custom_args(self, provider):
         payload = get_basic_payload()
         payload['custom_args'] = {'key': 'value'}
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_send_at(self, provider):
         payload = get_basic_payload()
         payload['send_at'] = 1234
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_batch_id(self, provider):
         payload = get_basic_payload()
         payload['batch_id'] = 'batch id'
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_asm(self, provider):
         payload = get_basic_payload()
         payload['asm'] = {
             'group_id': 1234,
-            'groups_to_display': [1,2,3]
+            'groups_to_display': [1, 2, 3]
         }
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_asm_no_group_id(self, provider):
         payload = get_basic_payload()
@@ -430,7 +433,7 @@ class TestSendgridSchema:
     def test_ip_pool_name(self, provider):
         payload = get_basic_payload()
         payload['ip_pool_name'] = 'asdf'
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_mail_settings(self, provider):
         payload = get_basic_payload()
@@ -456,7 +459,7 @@ class TestSendgridSchema:
                 'post_to_url': 'http://foo.com'
             }
         }
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_tracking_settings(self, provider):
         payload = get_basic_payload()
@@ -480,30 +483,30 @@ class TestSendgridSchema:
                 'utm_campaign': 'something'
             }
         }
-        assert(provider._process_data(**payload) == payload)
+        assert provider._process_data(**payload) == payload
 
     def test_from_(self, provider):
         payload = get_basic_payload()
         payload['from_'] = payload.pop('from')
-        assert(provider._process_data(**payload) == get_basic_payload())
+        assert provider._process_data(**payload) == get_basic_payload()
 
     def test_message(self, provider):
         payload = get_basic_payload()
         payload['message'] = payload['content'][0]['value']
-        del(payload['content'])
-        assert(provider._process_data(**payload) == get_basic_payload())
+        del payload['content']
+        assert provider._process_data(**payload) == get_basic_payload()
 
     def test_to(self, provider):
         payload = get_basic_payload()
         payload['to'] = payload['personalizations'][0]['to'][0]['email']
-        del(payload['personalizations'])
-        assert(provider._process_data(**payload) == get_basic_payload())
+        del payload['personalizations']
+        assert provider._process_data(**payload) == get_basic_payload()
 
     def test_to_and_personalizations(self, provider):
         payload = get_basic_payload()
         payload['to'] = 'test@example.com'
         expected_payload = payload
-        del(expected_payload['to'])
+        del expected_payload['to']
         expected_payload['personalizations'].append(
             {
                 'to': [
@@ -513,7 +516,7 @@ class TestSendgridSchema:
                 ]
             }
         )
-        assert(provider._process_data(**payload) == expected_payload)
+        assert provider._process_data(**payload) == expected_payload
 
 def get_online_basic_payload():
     """
@@ -522,7 +525,7 @@ def get_online_basic_payload():
     """
     payload = get_basic_payload()
     # delete this so that the 'to' from the environment gets read in instead
-    del(payload['personalizations'])
+    del payload['personalizations']
     return payload
 
 class TestSendgridOnline:

--- a/tests/providers/test_sendgrid.py
+++ b/tests/providers/test_sendgrid.py
@@ -12,6 +12,7 @@ import re
 import copy
 import base64
 import pytest
+from unittest.mock import MagicMock
 from notifiers.exceptions import BadArguments
 provider = 'sendgrid'
 
@@ -23,6 +24,7 @@ def get_basic_payload():
     having to worry about required arguments
     """
     return {
+        'api_key': '1234',
         'personalizations': [
             {
                 'to': [
@@ -59,6 +61,13 @@ def get_attachment_payload():
 
 class TestSendgridSchema:
     """Tests just the schema validation for SG"""
+
+    @pytest.fixture(autouse=True)
+    def patch_requests(self, monkeypatch):
+        def requests_return(**kwargs):
+            return MagicMock(), []
+        monkeypatch.setattr('notifiers.utils.requests.post', requests_return)
+
     old_environ = {}
 
     @classmethod
@@ -74,7 +83,6 @@ class TestSendgridSchema:
     @classmethod
     def teardown_class(cls):
         """put the NOTIFIERS variables back for other tests"""
-        print(cls.old_environ)
         for each in cls.old_environ:
             os.environ[each] = cls.old_environ[each]
 
@@ -86,7 +94,7 @@ class TestSendgridSchema:
         })
 
     def test_basic_payload(self, provider):
-        provider._process_data(**get_basic_payload())
+        rsp = provider.notify(**get_basic_payload())
 
     to_payloads = [
         (
@@ -152,7 +160,7 @@ class TestSendgridSchema:
         full_payload = get_basic_payload()
         full_payload.update(payload)
         with pytest.raises(BadArguments, match=error):
-            provider._validate_data(full_payload)
+            provider.notify(**full_payload)
 
     def test_personalization_multiple_to(self, provider):
         payload = get_basic_payload()
@@ -172,7 +180,7 @@ class TestSendgridSchema:
                 }
             ]
         })
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_personalization_simple_cc_and_bcc(self, provider):
         payload = get_basic_payload()
@@ -200,232 +208,232 @@ class TestSendgridSchema:
                 }
             ]
         })
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_personalization_headers(self, provider):
         payload = get_basic_payload()
         payload['personalizations'][0]['headers'] = {'X-Whatever': 'Value'}
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_personalization_subject(self, provider):
         payload = get_basic_payload()
         payload['personalizations'][0]['subject'] = 'my subject'
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_personalization_substitutions(self, provider):
         payload = get_basic_payload()
         payload['personalizations'][0]['substitutions'] = {'key': 'value'}
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_personalization_custom_args(self, provider):
         payload = get_basic_payload()
         payload['personalizations'][0]['custom_args'] = {'key': 'value'}
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_addtional_properties_in_personalizations(self, provider):
         payload = get_basic_payload()
         payload['personalizations'][0]['bad_data'] = 1234
         with pytest.raises(BadArguments, match="'bad_data' was unexpected"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_multiple_personalizations(self, provider):
         payload = get_basic_payload()
         payload['personalizations'].append(payload['personalizations'][0])
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_from_missing(self, provider):
         payload = get_basic_payload()
         del payload['from']
         with pytest.raises(BadArguments,
                            match="'from' is a required property"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_from_email_missing(self, provider):
         payload = get_basic_payload()
         del payload['from']['email']
         with pytest.raises(BadArguments,
                            match="'email' is a required property"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_from_name(self, provider):
         payload = get_basic_payload()
         payload['from']['name'] = 'bill'
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_from_additional_properties(self, provider):
         payload = get_basic_payload()
         payload['from']['bad_data'] = 1234
         with pytest.raises(BadArguments, match="'bad_data' was unexpected"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_reply_to_email_missing(self, provider):
         payload = get_basic_payload()
         payload['reply_to'] = {}
         with pytest.raises(BadArguments,
                            match="'email' is a required property"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_email_name(self, provider):
         payload = get_basic_payload()
         payload['reply_to'] = {'name': 'bill', 'email': 'test@example.com'}
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_reply_to_additional_properties(self, provider):
         payload = get_basic_payload()
         payload['reply_to'] = {'bad_data': 1234}
         with pytest.raises(BadArguments, match="'bad_data' was unexpected"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_subject_missing(self, provider):
         payload = get_basic_payload()
         del payload['subject']
         with pytest.raises(BadArguments,
                            match="'subject' is a required property"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_empty_subject(self, provider):
         payload = get_basic_payload()
         payload['subject'] = ''
         with pytest.raises(BadArguments, match="'' is too short"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_no_content(self, provider):
         payload = get_basic_payload()
         del payload['content']
         with pytest.raises(BadArguments,
                            match="'content' is a required property"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_missing_mime_type(self, provider):
         payload = get_basic_payload()
         del payload['content'][0]['type']
         with pytest.raises(BadArguments,
                            match="'type' is a required property"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_missing_content_value(self, provider):
         payload = get_basic_payload()
         del payload['content'][0]['value']
         with pytest.raises(BadArguments,
                            match="'value' is a required property"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_empty_mime_type(self, provider):
         payload = get_basic_payload()
         payload['content'][0]['type'] = ''
         with pytest.raises(BadArguments, match="'' is too short"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_empty_content_value(self, provider):
         payload = get_basic_payload()
         payload['content'][0]['value'] = ''
         with pytest.raises(BadArguments, match="'' is too short"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_basic_attachment_payload(self, provider):
         payload = get_attachment_payload()
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_attachment_content_missing(self, provider):
         payload = get_attachment_payload()
         del payload['attachments'][0]['content']
         with pytest.raises(BadArguments,
                            match="'content' is a required property"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_attachment_filename_missing(self, provider):
         payload = get_attachment_payload()
         del payload['attachments'][0]['filename']
         with pytest.raises(BadArguments,
                            match="'filename' is a required property"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_empty_attachment_content(self, provider):
         payload = get_attachment_payload()
         payload['attachments'][0]['content'] = ''
         with pytest.raises(BadArguments, match="'' is too short"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_empty_attachment_filename(self, provider):
         payload = get_attachment_payload()
         payload['attachments'][0]['filename'] = ''
         with pytest.raises(BadArguments, match="'' is too short"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_attachment_extra_properties(self, provider):
         payload = get_attachment_payload()
         payload['attachments'][0]['bad_data'] = 1234
         with pytest.raises(BadArguments, match="'bad_data' was unexpected"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_attachment_disposition_inline(self, provider):
         payload = get_attachment_payload()
         payload['attachments'][0]['disposition'] = 'inline'
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_attachment_disposition_attachment(self, provider):
         payload = get_attachment_payload()
         payload['attachments'][0]['disposition'] = 'attachment'
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_attachment_bad_disposition(self, provider):
         payload = get_attachment_payload()
         payload['attachments'][0]['disposition'] = 'bad_data'
         with pytest.raises(BadArguments, match="'bad_data' is not one of"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_attachment_content_id(self, provider):
         payload = get_attachment_payload()
         payload['attachments'][0]['content_id'] = 'string'
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_template_id(self, provider):
         payload = get_basic_payload()
         payload['template_id'] = 'string'
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_sections(self, provider):
         payload = get_basic_payload()
         payload['sections'] = {'key': 'value', 'key2': 'value'}
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_headers(self, provider):
         payload = get_basic_payload()
         payload['headers'] = {'key': 'value', 'key2': 'value'}
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_categories(self, provider):
         payload = get_basic_payload()
         payload['categories'] = ['a', 'b', 'c']
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_non_unique_categories(self, provider):
         payload = get_basic_payload()
         payload['categories'] = ['a', 'a', 'a']
         with pytest.raises(BadArguments, match="has non-unique elements"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_custom_args(self, provider):
         payload = get_basic_payload()
         payload['custom_args'] = {'key': 'value'}
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_send_at_invalid_timestamp(self, provider):
         payload = get_basic_payload()
         payload['send_at'] = 9999999999999999
         with pytest.raises(BadArguments,
                            match=" 9999999999999999 is not a 'timestamp'"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_send_at_valid(self, provider):
         payload = get_basic_payload()
         payload['send_at'] = 1534297539
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_batch_id(self, provider):
         payload = get_basic_payload()
         payload['batch_id'] = 'batch id'
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_asm(self, provider):
         payload = get_basic_payload()
@@ -433,14 +441,14 @@ class TestSendgridSchema:
             'group_id': 1234,
             'groups_to_display': [1, 2, 3]
         }
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_asm_no_group_id(self, provider):
         payload = get_basic_payload()
         payload['asm'] = {}
         with pytest.raises(BadArguments,
                            match="'group_id' is a required property"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_asm_additional_properties(self, provider):
         payload = get_basic_payload()
@@ -449,12 +457,12 @@ class TestSendgridSchema:
             'bad_data': 1
         }
         with pytest.raises(BadArguments, match="'bad_data' was unexpected"):
-            provider._process_data(**payload)
+            provider.notify(**payload)
 
     def test_ip_pool_name(self, provider):
         payload = get_basic_payload()
         payload['ip_pool_name'] = 'asdf'
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_mail_settings(self, provider):
         payload = get_basic_payload()
@@ -480,10 +488,11 @@ class TestSendgridSchema:
         }
 
         expected_payload = copy.deepcopy(payload)
+        del expected_payload['api_key']
         expected_payload['mail_settings']['sandbox_mode'] = {
             'enable': True
         }
-        assert provider._process_data(**payload) == expected_payload
+        assert provider.notify(**payload).data == expected_payload
 
     def test_tracking_settings(self, provider):
         payload = get_basic_payload()
@@ -507,29 +516,35 @@ class TestSendgridSchema:
                 'utm_campaign': 'something'
             }
         }
-        assert provider._process_data(**payload) == payload
+        provider.notify(**payload)
 
     def test_from_(self, provider):
         payload = get_basic_payload()
         payload['from_'] = payload.pop('from')
-        assert provider._process_data(**payload) == get_basic_payload()
+        expected_payload = get_basic_payload()
+        del expected_payload['api_key']
+        assert provider.notify(**payload).data == expected_payload
 
     def test_message(self, provider):
         payload = get_basic_payload()
         payload['message'] = payload['content'][0]['value']
         del payload['content']
-        assert provider._process_data(**payload) == get_basic_payload()
+        expected_payload = get_basic_payload()
+        del expected_payload['api_key']
+        assert provider.notify(**payload).data == expected_payload
 
     def test_to(self, provider):
         payload = get_basic_payload()
         payload['to'] = payload['personalizations'][0]['to'][0]['email']
         del payload['personalizations']
-        assert provider._process_data(**payload) == get_basic_payload()
+        expected_payload = get_basic_payload()
+        del expected_payload['api_key']
+        assert provider.notify(**payload).data == expected_payload
 
     def test_to_and_personalizations(self, provider):
         payload = get_basic_payload()
         payload['to'] = 'test@example.com'
-        expected_payload = payload
+        expected_payload = copy.deepcopy(payload)
         del expected_payload['to']
         expected_payload['personalizations'].append(
             {
@@ -540,12 +555,15 @@ class TestSendgridSchema:
                 ]
             }
         )
-        assert provider._process_data(**payload) == expected_payload
+        del expected_payload['api_key']
+        assert provider.notify(**payload).data == expected_payload
 
     def test_bare_from(self, provider):
         payload = get_basic_payload()
         payload['from'] = 'test@example.com'
-        assert provider._process_data(**payload) == get_basic_payload()
+        expected_payload = get_basic_payload()
+        del expected_payload['api_key']
+        assert provider.notify(**payload).data == expected_payload
 
 
 def get_online_basic_payload():
@@ -556,6 +574,7 @@ def get_online_basic_payload():
     payload = get_basic_payload()
     # delete this so that the 'to' from the environment gets read in instead
     del payload['personalizations']
+    del payload['api_key']
     return payload
 
 
@@ -570,10 +589,18 @@ class TestSendgridOnline:
     def test_full_payload(self, provider):
         # this tests all the payload options that can be used realistically
         # on the free tier
-        payload = get_basic_payload()
+        payload = get_online_basic_payload()
         # make sure the personalized email gets inboxed
-        payload['personalizations'][0]['to'][0]['email'] =\
-            os.environ.get('NOTIFIERS_SENDGRID_TO')
+        payload['personalizations'] = [
+            {
+                'to': [
+                    {
+                        'email': os.environ.get('NOTIFIERS_SENDGRID_TO')
+                    }
+                ]
+            }
+        ]
+
         payload['personalizations'][0]['substitutions'] = {
             '{{name}}': 'Kenobi',
             '{{person}}': '{{person_section}}'

--- a/tests/providers/test_sendgrid.py
+++ b/tests/providers/test_sendgrid.py
@@ -518,6 +518,11 @@ class TestSendgridSchema:
         )
         assert provider._process_data(**payload) == expected_payload
 
+    def test_bare_from(self, provider):
+        payload = get_basic_payload()
+        payload['from'] = 'test@example.com'
+        assert provider._process_data(**payload) == get_basic_payload()
+
 def get_online_basic_payload():
     """
     Gets a basic payload with the live variables deleted, so that


### PR DESCRIPTION
Adds a 'sendgrid' provider and accompanying tests.  The SG API is very complex, even when it comes to setting the 'from' and 'to' on a message, so I set it up for those to allow plain strings instead of the JSON objects they usually require.  Tested the schema pretty in depth as well.  The CLI also is working for me.

I noticed an issue in how json schema errors are rendered during this.  It only renders the top-level error in the exception, not the full path to the variable in question.  Other APIs seem to be pretty simple, so maybe this isn't a big deal for them, but SG is very intricate and tracking down errors without the schema path to the problem variable is a pain.  I'll log a separate ticket to fix this (it doesn't look like it'll be that hard).