### PR TITLE
Add a timeout on requests

### DIFF
--- a/notifiers/utils/requests.py
+++ b/notifiers/utils/requests.py
@@ -30,6 +30,8 @@ class RequestsHelper:
         :return: Dict of response body or original :class:`requests.Response`
         """
         session = kwargs.get("session", requests.Session())
+        if 'timeout' not in kwargs:
+            kwargs['timeout'] = (5, 20)
         log.debug(
             "sending a %s request to %s with args: %s kwargs: %s",
             method.upper(),

--- a/source/changelog.rst
+++ b/source/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 (Unreleased)
 ------------
 
+- Adds a default timeout of (5, 20) seconds for all HTTP requests. (`#388 <https://github.com/liiight/notifiers/pull/388>`_)
+
 1.2.0
 -----
 


### PR DESCRIPTION
/* If we're interested in moving forward with this contribution, I can look into adding testing/maybe cleaning things up, but would like to get directional alignment before investing further effort. */

Currently, there isn't a timeout specified on http requests, which means that requests can block the calling thread for potentially unbounded periods of time.

This isn't the cleanest way to do it--ideally I'd have it be exposed to users of the library to configure--but it's better than nothing.

Admittedly, I haven't spent much time digging around the current setup, so if there's a cleaner way of doing this (outside of a larger refactor), I'm all ears.

https://requests.readthedocs.io/en/master/user/quickstart/#timeouts
https://requests.readthedocs.io/en/master/user/advanced/#timeouts