### PR TITLE
docs: fix simple typo, reservred -> reserved

### DIFF
--- a/notifiers/utils/requests.py
+++ b/notifiers/utils/requests.py
@@ -30,8 +30,8 @@ class RequestsHelper:
         :return: Dict of response body or original :class:`requests.Response`
         """
         session = kwargs.get("session", requests.Session())
-        if 'timeout' not in kwargs:
-            kwargs['timeout'] = (5, 20)
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = (5, 20)
         log.debug(
             "sending a %s request to %s with args: %s kwargs: %s",
             method.upper(),

--- a/source/about.rst
+++ b/source/about.rst
@@ -44,7 +44,7 @@ The first is to construct data via a dict and unpack it into the :meth:`~notifie
    ... }
    >>> provider.notify(**data)
 
-The other is to use an alternate key word, which would always be the reservred key word followed by an underscore:
+The other is to use an alternate key word, which would always be the reserved key word followed by an underscore:
 
 .. code:: python
 

--- a/source/providers/telegram.rst
+++ b/source/providers/telegram.rst
@@ -9,7 +9,7 @@ Minimal example:
     >>> from notifiers import get_notifier
     >>> telegram = get_notifier('telegram')
     >>> telegram.notify(message='Hi!', token='TOKEN', chat_id=1234)
-    
+
 See `here <https://stackoverflow.com/a/32572159/10251805>` for an example how to retrieve the ``chat_id`` for your bot.
 
 You can view the available updates you can access via the ``updates`` resource


### PR DESCRIPTION
There is a small typo in source/about.rst.

Should read `reserved` rather than `reservred`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md