### PR TITLE
[WIP] Add MSTeams notifier

### DIFF
--- a/notifiers/providers/__init__.py
+++ b/notifiers/providers/__init__.py
@@ -4,6 +4,7 @@ from . import gmail
 from . import icloud
 from . import join
 from . import mailgun
+from . import msteams
 from . import pagerduty
 from . import popcornnotify
 from . import pushbullet
@@ -34,4 +35,5 @@ _all_providers = {
     "popcornnotify": popcornnotify.PopcornNotify,
     "statuspage": statuspage.Statuspage,
     "victorops": victorops.VictorOps,
+    "msteams": msteams.MSTeams,
 }

--- a/notifiers/providers/msteams.py
+++ b/notifiers/providers/msteams.py
@@ -20,6 +20,7 @@ class MSTeams(Provider):
             "message": {"type": "string", "title": "body of the notification"},
             "title": {"type": "string", "title": "title of notification"},
         },
+        "additionalProperties": True
     }
 
     _required = {"required": ["message", "webhook_url"]}

--- a/notifiers/providers/msteams.py
+++ b/notifiers/providers/msteams.py
@@ -6,7 +6,7 @@ from ..utils import requests
 class MSTeams(Provider):
     """Send MS Teams notification with title and message."""
 
-    base_url = "https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook"
+    base_url = ""
     site_url = "https://www.microsoft.com/en-en/microsoft-teams"
     name = "msteams"
 

--- a/notifiers/providers/msteams.py
+++ b/notifiers/providers/msteams.py
@@ -19,13 +19,16 @@ class MSTeams(Provider):
             },
             "message": {"type": "string", "title": "body of the notification"},
             "title": {"type": "string", "title": "title of notification"},
+            "color": {"type": "string", "title": "color of the card",
+                      "pattern": "^#?([A-Fa-f0-9]{6})$"},
             "button": {
                 "type": "object",
                 "properties": {
                     "name": {"type": "string", "title": "Name of the button"},
-                    "target": {"type": "string", "title": "URL address of the target"},
-                },
-            },
+                    "target": {"type": "string", "title": "URL address of the target",
+                               "pattern": "^https?://"},
+                }
+            }
         },
         "additionalProperties": True,
     }
@@ -36,6 +39,11 @@ class MSTeams(Provider):
         # process text/message
         text = data.pop("message")
         data["text"] = text
+
+        # process color
+        if "color" in data.keys():
+            clr = data.pop("color")
+            data["themeColor"] = f"#{clr}" if not clr.startswith("#") else clr
 
         # process button
         if "button" in data.keys():
@@ -53,5 +61,6 @@ class MSTeams(Provider):
 
     def _send_notification(self, data: dict) -> Response:
         url = data.pop("webhook_url")
+        print(data)
         response, errors = requests.post(url, json=data)
         return self.create_response(data, response, errors)

--- a/notifiers/providers/msteams.py
+++ b/notifiers/providers/msteams.py
@@ -23,9 +23,9 @@ class MSTeams(Provider):
                 "type": "object",
                 "properties": {
                     "name": {"type": "string", "title": "Name of the button"},
-                    "target": {"type": "string", "title": "URL address of the target"}
-                }
-            }
+                    "target": {"type": "string", "title": "URL address of the target"},
+                },
+            },
         },
         "additionalProperties": True,
     }
@@ -45,7 +45,7 @@ class MSTeams(Provider):
                 "@context": "http://schema.org",
                 "@type": "ViewAction",
                 "name": data["button"]["name"],
-                "target": [data["button"]["target"]]
+                "target": [data["button"]["target"]],
             }
             data["potentialAction"].append(button)
             data.pop("button")
@@ -55,4 +55,3 @@ class MSTeams(Provider):
         url = data.pop("webhook_url")
         response, errors = requests.post(url, json=data)
         return self.create_response(data, response, errors)
-

--- a/notifiers/providers/msteams.py
+++ b/notifiers/providers/msteams.py
@@ -19,6 +19,13 @@ class MSTeams(Provider):
             },
             "message": {"type": "string", "title": "body of the notification"},
             "title": {"type": "string", "title": "title of notification"},
+            "button": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "title": "Name of the button"},
+                    "target": {"type": "string", "title": "URL address of the target"}
+                }
+            }
         },
         "additionalProperties": True,
     }
@@ -26,11 +33,26 @@ class MSTeams(Provider):
     _required = {"required": ["message", "webhook_url"]}
 
     def _prepare_data(self, data: dict) -> dict:
+        # process text/message
         text = data.pop("message")
         data["text"] = text
+
+        # process button
+        if "button" in data.keys():
+            if "potentialAction" not in data.keys():
+                data["potentialAction"] = []
+            button = {
+                "@context": "http://schema.org",
+                "@type": "ViewAction",
+                "name": data["button"]["name"],
+                "target": [data["button"]["target"]]
+            }
+            data["potentialAction"].append(button)
+            data.pop("button")
         return data
 
     def _send_notification(self, data: dict) -> Response:
         url = data.pop("webhook_url")
         response, errors = requests.post(url, json=data)
         return self.create_response(data, response, errors)
+

--- a/notifiers/providers/msteams.py
+++ b/notifiers/providers/msteams.py
@@ -1,0 +1,35 @@
+from ..core import Provider
+from ..core import Response
+from ..utils import requests
+
+
+class MSTeams(Provider):
+    """Send MS Teams notification with title and message."""
+
+    base_url = "https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook"
+    site_url = "https://www.microsoft.com/en-en/microsoft-teams"
+    name = "msteams"
+
+    _schema = {
+        "type": "object",
+        "properties": {
+            "webhook_url": {
+                "type": "string",
+                "title": "webhook url for MS Teams channel",
+            },
+            "message": {"type": "string", "title": "body of the notification"},
+            "title": {"type": "string", "title": "title of notification"},
+        },
+    }
+
+    _required = {"required": ["message", "webhook_url"]}
+
+    def _prepare_data(self, data: dict) -> dict:
+        text = data.pop("message")
+        data["text"] = text
+        return data
+
+    def _send_notification(self, data: dict) -> Response:
+        url = data.pop("webhook_url")
+        response, errors = requests.post(url, json=data)
+        return self.create_response(data, response, errors)

--- a/notifiers/providers/msteams.py
+++ b/notifiers/providers/msteams.py
@@ -20,7 +20,7 @@ class MSTeams(Provider):
             "message": {"type": "string", "title": "body of the notification"},
             "title": {"type": "string", "title": "title of notification"},
         },
-        "additionalProperties": True
+        "additionalProperties": True,
     }
 
     _required = {"required": ["message", "webhook_url"]}

--- a/source/conf.py
+++ b/source/conf.py
@@ -76,7 +76,7 @@ except ImportError:
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/source/providers/msteams.rst
+++ b/source/providers/msteams.rst
@@ -1,0 +1,100 @@
+MSTeams
+-------
+Send notification wiab MS Teams Webhook.
+Basic usage is with parameters ``message`` and optional ``title``.
+For more advanced usage, additional parameters are allowed. See examples below:
+
+.. code-block:: python
+
+    >>> from notifiers import get_notifier
+    >>> teams = get_notifier("msteams")
+    >>> # 1) basic usage
+    >>> data = {"message": "Foo", "title": "Bar", "webhook_url": "YOUR_WEBHOOK"}
+    >>> teams.notify(**data)
+    >>> # 2) more complex message
+    >>> advanced_message = {
+            "webhook_url": "YOUR_WEBHOOK",
+            "message": "Example of advanced Teams Card, "
+                       "source: https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL",
+            "@type": "MessageCard",
+            "@context": "http://schema.org/extensions",
+            "themeColor": "0076D7",
+            "summary": "Larry Bryant created a new task",
+            "sections": [{
+                "activityTitle": "Larry Bryant created a new task",
+                "activitySubtitle": "On Project Tango",
+                "activityImage": "https://teamsnodesample.azurewebsites.net/static/img/image5.png",
+                "facts": [{
+                    "name": "Assigned to",
+                    "value": "Unassigned"
+                }, {
+                    "name": "Due date",
+                    "value": "Mon May 01 2017 17:07:18 GMT-0700 (Pacific Daylight Time)"
+                }, {
+                    "name": "Status",
+                    "value": "Not started"
+                }],
+                "markdown": True
+            }],
+            "potentialAction": [{
+                "@type": "ActionCard",
+                "name": "Add a comment",
+                "inputs": [{
+                    "@type": "TextInput",
+                    "id": "comment",
+                    "isMultiline": False,
+                    "title": "Add a comment here for this task"
+                }],
+                "actions": [{
+                    "@type": "HttpPOST",
+                    "name": "Add comment",
+                    "target": "https://learn.microsoft.com/outlook/actionable-messages"
+                }]
+            }, {
+                "@type": "ActionCard",
+                "name": "Set due date",
+                "inputs": [{
+                    "@type": "DateInput",
+                    "id": "dueDate",
+                    "title": "Enter a due date for this task"
+                }],
+                "actions": [{
+                    "@type": "HttpPOST",
+                    "name": "Save",
+                    "target": "https://learn.microsoft.com/outlook/actionable-messages"
+                }]
+            }, {
+                "@type": "OpenUri",
+                "name": "Learn More",
+                "targets": [{
+                    "os": "default",
+                    "uri": "https://learn.microsoft.com/outlook/actionable-messages"
+                }]
+            }, {
+                "@type": "ActionCard",
+                "name": "Change status",
+                "inputs": [{
+                    "@type": "MultichoiceInput",
+                    "id": "list",
+                    "title": "Select a status",
+                    "isMultiSelect": "false",
+                    "choices": [{
+                        "display": "In Progress",
+                        "value": "1"
+                    }, {
+                        "display": "Active",
+                        "value": "2"
+                    }, {
+                        "display": "Closed",
+                        "value": "3"
+                    }]
+                }],
+                "actions": [{
+                    "@type": "HttpPOST",
+                    "name": "Save",
+                    "target": "https://learn.microsoft.com/outlook/actionable-messages"
+                }]
+            }]
+        }
+    >>> teams.notify(**advanced_message)
+

--- a/tests/providers/test_msteams.py
+++ b/tests/providers/test_msteams.py
@@ -1,0 +1,2 @@
+import pytest
+

--- a/tests/providers/test_msteams.py
+++ b/tests/providers/test_msteams.py
@@ -1,2 +1,21 @@
 import pytest
 
+from notifiers.exceptions import NotificationError, BadArguments
+
+provider = "msteams"
+
+
+class TestMSTeams:
+    """MS Teams tests"""
+
+    @pytest.mark.parametrize(
+        "data, missing", [
+            ({"title": "foo", "webhook_url": "bar"}, "message"),
+            ({"message": "foo"}, "webhook_url")
+        ]
+    )
+    def test_msteams_missing_required(self, data, missing, provider):
+        data["end_prefix"] = "test"
+        with pytest.raises(BadArguments) as e:
+            provider.notify(**data)
+        assert f"'{missing}' is a required property" in e.value.message

--- a/tests/providers/test_msteams.py
+++ b/tests/providers/test_msteams.py
@@ -5,7 +5,8 @@ from notifiers.exceptions import BadArguments
 provider = "msteams"
 connector_message_example = {
     "message": "Example of advanced Teams Card, "
-               "source: https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL",
+               "source: https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/"
+               "connectors-using?tabs=cURL",
     "@type": "MessageCard",
     "@context": "http://schema.org/extensions",
     "themeColor": "0076D7",

--- a/tests/providers/test_msteams.py
+++ b/tests/providers/test_msteams.py
@@ -5,87 +5,101 @@ from notifiers.exceptions import BadArguments
 provider = "msteams"
 connector_message_example = {
     "message": "Example of advanced Teams Card, "
-               "source: https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/"
-               "connectors-using?tabs=cURL",
+    "source: https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/"
+    "connectors-using?tabs=cURL",
     "@type": "MessageCard",
     "@context": "http://schema.org/extensions",
     "themeColor": "0076D7",
     "summary": "Larry Bryant created a new task",
-    "sections": [{
-        "activityTitle": "Larry Bryant created a new task",
-        "activitySubtitle": "On Project Tango",
-        "activityImage": "https://teamsnodesample.azurewebsites.net/static/img/image5.png",
-        "facts": [{
-            "name": "Assigned to",
-            "value": "Unassigned"
-        }, {
-            "name": "Due date",
-            "value": "Mon May 01 2017 17:07:18 GMT-0700 (Pacific Daylight Time)"
-        }, {
-            "name": "Status",
-            "value": "Not started"
-        }],
-        "markdown": True
-    }],
-    "potentialAction": [{
-        "@type": "ActionCard",
-        "name": "Add a comment",
-        "inputs": [{
-            "@type": "TextInput",
-            "id": "comment",
-            "isMultiline": False,
-            "title": "Add a comment here for this task"
-        }],
-        "actions": [{
-            "@type": "HttpPOST",
-            "name": "Add comment",
-            "target": "https://learn.microsoft.com/outlook/actionable-messages"
-        }]
-    }, {
-        "@type": "ActionCard",
-        "name": "Set due date",
-        "inputs": [{
-            "@type": "DateInput",
-            "id": "dueDate",
-            "title": "Enter a due date for this task"
-        }],
-        "actions": [{
-            "@type": "HttpPOST",
-            "name": "Save",
-            "target": "https://learn.microsoft.com/outlook/actionable-messages"
-        }]
-    }, {
-        "@type": "OpenUri",
-        "name": "Learn More",
-        "targets": [{
-            "os": "default",
-            "uri": "https://learn.microsoft.com/outlook/actionable-messages"
-        }]
-    }, {
-        "@type": "ActionCard",
-        "name": "Change status",
-        "inputs": [{
-            "@type": "MultichoiceInput",
-            "id": "list",
-            "title": "Select a status",
-            "isMultiSelect": "false",
-            "choices": [{
-                "display": "In Progress",
-                "value": "1"
-            }, {
-                "display": "Active",
-                "value": "2"
-            }, {
-                "display": "Closed",
-                "value": "3"
-            }]
-        }],
-        "actions": [{
-            "@type": "HttpPOST",
-            "name": "Save",
-            "target": "https://learn.microsoft.com/outlook/actionable-messages"
-        }]
-    }]
+    "sections": [
+        {
+            "activityTitle": "Larry Bryant created a new task",
+            "activitySubtitle": "On Project Tango",
+            "activityImage": "https://teamsnodesample.azurewebsites.net/static/img/image5.png",
+            "facts": [
+                {"name": "Assigned to", "value": "Unassigned"},
+                {
+                    "name": "Due date",
+                    "value": "Mon May 01 2017 17:07:18 GMT-0700 (Pacific Daylight Time)",
+                },
+                {"name": "Status", "value": "Not started"},
+            ],
+            "markdown": True,
+        }
+    ],
+    "potentialAction": [
+        {
+            "@type": "ActionCard",
+            "name": "Add a comment",
+            "inputs": [
+                {
+                    "@type": "TextInput",
+                    "id": "comment",
+                    "isMultiline": False,
+                    "title": "Add a comment here for this task",
+                }
+            ],
+            "actions": [
+                {
+                    "@type": "HttpPOST",
+                    "name": "Add comment",
+                    "target": "https://learn.microsoft.com/outlook/actionable-messages",
+                }
+            ],
+        },
+        {
+            "@type": "ActionCard",
+            "name": "Set due date",
+            "inputs": [
+                {
+                    "@type": "DateInput",
+                    "id": "dueDate",
+                    "title": "Enter a due date for this task",
+                }
+            ],
+            "actions": [
+                {
+                    "@type": "HttpPOST",
+                    "name": "Save",
+                    "target": "https://learn.microsoft.com/outlook/actionable-messages",
+                }
+            ],
+        },
+        {
+            "@type": "OpenUri",
+            "name": "Learn More",
+            "targets": [
+                {
+                    "os": "default",
+                    "uri": "https://learn.microsoft.com/outlook/actionable-messages",
+                }
+            ],
+        },
+        {
+            "@type": "ActionCard",
+            "name": "Change status",
+            "inputs": [
+                {
+                    "@type": "MultichoiceInput",
+                    "id": "list",
+                    "title": "Select a status",
+                    "isMultiSelect": "false",
+                    "choices": [
+                        {"display": "In Progress", "value": "1"},
+                        {"display": "Active", "value": "2"},
+                        {"display": "Closed", "value": "3"},
+                    ],
+                }
+            ],
+            "actions": [
+                {
+                    "@type": "HttpPOST",
+                    "name": "Save",
+                    "target": "https://learn.microsoft.com/outlook/actionable-messages",
+                }
+            ],
+        },
+    ],
 }
 
 
@@ -93,10 +107,11 @@ class TestMSTeams:
     """MS Teams tests"""
 
     @pytest.mark.parametrize(
-        "data, missing", [
+        "data, missing",
+        [
             ({"title": "foo", "webhook_url": "bar"}, "message"),
-            ({"message": "foo"}, "webhook_url")
-        ]
+            ({"message": "foo"}, "webhook_url"),
+        ],
     )
     def test_msteams_missing_required(self, data, missing, provider):
         data["end_prefix"] = "test"

--- a/tests/providers/test_msteams.py
+++ b/tests/providers/test_msteams.py
@@ -1,8 +1,91 @@
 import pytest
 
-from notifiers.exceptions import NotificationError, BadArguments
+from notifiers.exceptions import BadArguments
 
 provider = "msteams"
+connector_message_example = {
+    "message": "Example of advanced Teams Card, "
+               "source: https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL",
+    "@type": "MessageCard",
+    "@context": "http://schema.org/extensions",
+    "themeColor": "0076D7",
+    "summary": "Larry Bryant created a new task",
+    "sections": [{
+        "activityTitle": "Larry Bryant created a new task",
+        "activitySubtitle": "On Project Tango",
+        "activityImage": "https://teamsnodesample.azurewebsites.net/static/img/image5.png",
+        "facts": [{
+            "name": "Assigned to",
+            "value": "Unassigned"
+        }, {
+            "name": "Due date",
+            "value": "Mon May 01 2017 17:07:18 GMT-0700 (Pacific Daylight Time)"
+        }, {
+            "name": "Status",
+            "value": "Not started"
+        }],
+        "markdown": True
+    }],
+    "potentialAction": [{
+        "@type": "ActionCard",
+        "name": "Add a comment",
+        "inputs": [{
+            "@type": "TextInput",
+            "id": "comment",
+            "isMultiline": False,
+            "title": "Add a comment here for this task"
+        }],
+        "actions": [{
+            "@type": "HttpPOST",
+            "name": "Add comment",
+            "target": "https://learn.microsoft.com/outlook/actionable-messages"
+        }]
+    }, {
+        "@type": "ActionCard",
+        "name": "Set due date",
+        "inputs": [{
+            "@type": "DateInput",
+            "id": "dueDate",
+            "title": "Enter a due date for this task"
+        }],
+        "actions": [{
+            "@type": "HttpPOST",
+            "name": "Save",
+            "target": "https://learn.microsoft.com/outlook/actionable-messages"
+        }]
+    }, {
+        "@type": "OpenUri",
+        "name": "Learn More",
+        "targets": [{
+            "os": "default",
+            "uri": "https://learn.microsoft.com/outlook/actionable-messages"
+        }]
+    }, {
+        "@type": "ActionCard",
+        "name": "Change status",
+        "inputs": [{
+            "@type": "MultichoiceInput",
+            "id": "list",
+            "title": "Select a status",
+            "isMultiSelect": "false",
+            "choices": [{
+                "display": "In Progress",
+                "value": "1"
+            }, {
+                "display": "Active",
+                "value": "2"
+            }, {
+                "display": "Closed",
+                "value": "3"
+            }]
+        }],
+        "actions": [{
+            "@type": "HttpPOST",
+            "name": "Save",
+            "target": "https://learn.microsoft.com/outlook/actionable-messages"
+        }]
+    }]
+}
 
 
 class TestMSTeams:
@@ -19,3 +102,12 @@ class TestMSTeams:
         with pytest.raises(BadArguments) as e:
             provider.notify(**data)
         assert f"'{missing}' is a required property" in e.value.message
+
+    @pytest.mark.online
+    def test_msteams_card(self, provider):
+        provider.notify(**connector_message_example)
+
+    @pytest.mark.online
+    def test_msteams_simple(self, provider):
+        data = {"message": "Foo", "title": "Bar"}
+        provider.notify(**data)


### PR DESCRIPTION
Hey, as I used this package but was missing MS Teams support, I have created simple notifier for MS Teams. 
As I read you wanted to wait for _pydantic_ support. In the meantime, someone might find this helpful.

* notifier name: `msteams`

Args:
* `webhook_url`: str, how to get one see [here](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook)
* `message` : str
* `title`: Optional[str]

Also more complex cards could be created, see tests..

Relates to: #44 

