### PR TITLE
add notify as provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Got an app or service, and you want to enable your users to use notifications wi
 # Supported providers
 
 
-[Pushover](https://pushover.net/), [SimplePush](https://simplepush.io/), [Slack](https://api.slack.com/), [Gmail](https://www.google.com/gmail/about/), Email (SMTP), [Telegram](https://telegram.org/), [Gitter](https://gitter.im), [Pushbullet](https://www.pushbullet.com), [Join](https://joaoapps.com/join/), [Zulip](https://zulipchat.com/), [Twilio](https://www.twilio.com/), [Pagerduty](https://www.pagerduty.com), [Mailgun](https://www.mailgun.com/), [PopcornNotify](https://popcornnotify.com), [StatusPage.io](https://statuspage.io), [iCloud](https://www.icloud.com/mail), [VictorOps (Splunk)](https://www.splunk.com/en_us/investor-relations/acquisitions/splunk-on-call.html)
+[Pushover](https://pushover.net/), [SimplePush](https://simplepush.io/), [Slack](https://api.slack.com/), [Gmail](https://www.google.com/gmail/about/), Email (SMTP), [Telegram](https://telegram.org/), [Gitter](https://gitter.im), [Pushbullet](https://www.pushbullet.com), [Join](https://joaoapps.com/join/), [Zulip](https://zulipchat.com/), [Twilio](https://www.twilio.com/), [Pagerduty](https://www.pagerduty.com), [Mailgun](https://www.mailgun.com/), [PopcornNotify](https://popcornnotify.com), [StatusPage.io](https://statuspage.io), [iCloud](https://www.icloud.com/mail), [VictorOps (Splunk)](https://www.splunk.com/en_us/investor-relations/acquisitions/splunk-on-call.html), [Notify](https://github.com/K0IN/Notify)
 
 # Advantages
 

--- a/notifiers/providers/__init__.py
+++ b/notifiers/providers/__init__.py
@@ -15,6 +15,7 @@ from . import telegram
 from . import twilio
 from . import victorops
 from . import zulip
+from . import notify
 
 _all_providers = {
     "pushover": pushover.Pushover,
@@ -34,4 +35,5 @@ _all_providers = {
     "popcornnotify": popcornnotify.PopcornNotify,
     "statuspage": statuspage.Statuspage,
     "victorops": victorops.VictorOps,
+    "notify": notify.Notify,
 }

--- a/notifiers/providers/__init__.py
+++ b/notifiers/providers/__init__.py
@@ -4,6 +4,7 @@ from . import gmail
 from . import icloud
 from . import join
 from . import mailgun
+from . import notify
 from . import pagerduty
 from . import popcornnotify
 from . import pushbullet
@@ -15,7 +16,6 @@ from . import telegram
 from . import twilio
 from . import victorops
 from . import zulip
-from . import notify
 
 _all_providers = {
     "pushover": pushover.Pushover,

--- a/notifiers/providers/notify.py
+++ b/notifiers/providers/notify.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from ..core import Provider
 from ..core import Response
 from ..utils import requests
@@ -10,18 +9,19 @@ class NotifyMixin:
     base_url = "{base_url}/api/notify"
     path_to_errors = ("message",)
 
-    def _get_headers(self, token: Optional[str]) -> dict:
+    def _get_headers(self, token: str) -> dict:
         """
         Builds Notify's requests header bases on the token provided
 
         :param token: Send token
         :return: Authentication header dict
         """
-        return {"Authorization": f"Bearer {token}"} if token else {}
+        return {"Authorization": f"Bearer {token}"}
 
 
 class Notify(NotifyMixin, Provider):
     """Send Notify notifications"""
+
     site_url = "https://github.com/K0IN/Notify"
     name = "notify"
 
@@ -34,7 +34,7 @@ class Notify(NotifyMixin, Provider):
             "title": {"type": "string", "title": "your message's title"},
             "token": {
                 "type": "string",
-                "title": "your application's send key, see https://github.com/K0IN/Notify/blob/main/doc/docker.md"
+                "title": "your application's send key, see https://github.com/K0IN/Notify/blob/main/doc/docker.md",
             },
             "tags": {
                 "type": "array",
@@ -50,7 +50,8 @@ class Notify(NotifyMixin, Provider):
 
     def _send_notification(self, data: dict) -> Response:
         url = self.base_url.format(base_url=data.pop("base_url"))
-        headers = self._get_headers(data.pop("token", None))
+        token = data.pop("token", None)
+        headers = self._get_headers(token) if token else {}
         response, errors = requests.post(
             url,
             json={

--- a/notifiers/providers/notify.py
+++ b/notifiers/providers/notify.py
@@ -1,11 +1,7 @@
 from typing import Optional
 from ..core import Provider
-from ..core import ProviderResource
 from ..core import Response
-from ..exceptions import ResourceError
 from ..utils import requests
-from ..utils.schema.helpers import list_to_commas
-from ..utils.schema.helpers import one_or_more
 
 
 class NotifyMixin:
@@ -33,10 +29,13 @@ class Notify(NotifyMixin, Provider):
     _schema = {
         "type": "object",
         "properties": {
-            "base_url": { "type": "string" },
-            "message": { "type": "string", "title": "your message"},
-            "title": { "type": "string", "title": "your message's title" },
-            "token": {"type": "string", "title": "your application's send key, see https://github.com/K0IN/Notify/blob/main/doc/docker.md"},
+            "base_url": {"type": "string"},
+            "message": {"type": "string", "title": "your message"},
+            "title": {"type": "string", "title": "your message's title"},
+            "token": {
+                "type": "string",
+                "title": "your application's send key, see https://github.com/K0IN/Notify/blob/main/doc/docker.md"
+            },
             "tags": {
                 "type": "array",
                 "title": "your message's tags",

--- a/notifiers/providers/notify.py
+++ b/notifiers/providers/notify.py
@@ -1,0 +1,65 @@
+from typing import Optional
+from ..core import Provider
+from ..core import ProviderResource
+from ..core import Response
+from ..exceptions import ResourceError
+from ..utils import requests
+from ..utils.schema.helpers import list_to_commas
+from ..utils.schema.helpers import one_or_more
+
+
+class NotifyMixin:
+    name = "notify"
+    site_url = "https://github.com/K0IN/Notify"
+    base_url = "{base_url}/api/notify"
+    path_to_errors = ("message",)
+
+    def _get_headers(self, token: Optional[str]) -> dict:
+        """
+        Builds Notify's requests header bases on the token provided
+
+        :param token: Send token
+        :return: Authentication header dict
+        """
+        return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+class Notify(NotifyMixin, Provider):
+    """Send Notify notifications"""
+    site_url = "https://github.com/K0IN/Notify"
+    name = "notify"
+
+    _required = {"required": ["title", "message", "base_url"]}
+    _schema = {
+        "type": "object",
+        "properties": {
+            "base_url": { "type": "string" },
+            "message": { "type": "string", "title": "your message"},
+            "title": { "type": "string", "title": "your message's title" },
+            "token": {"type": "string", "title": "your application's send key, see https://github.com/K0IN/Notify/blob/main/doc/docker.md"},
+            "tags": {
+                "type": "array",
+                "title": "your message's tags",
+                "items": {"type": "string"},
+            },
+        },
+        "additionalProperties": False,
+    }
+
+    def _prepare_data(self, data: dict) -> dict:
+        return data
+
+    def _send_notification(self, data: dict) -> Response:
+        url = self.base_url.format(base_url=data.pop("base_url"))
+        headers = self._get_headers(data.pop("token", None))
+        response, errors = requests.post(
+            url,
+            json={
+                "message": data.pop("message"),
+                "title": data.pop("title", None),
+                "tags": data.pop("tags", []),
+            },
+            headers=headers,
+            path_to_errors=self.path_to_errors,
+        )
+        return self.create_response(data, response, errors)

--- a/source/CLI.rst
+++ b/source/CLI.rst
@@ -34,6 +34,7 @@ To view the main help just enter ``notifiers`` or ``notifiers --help``:
       telegram    Options for 'telegram'
       zulip       Options for 'zulip'
       victorops       Options for 'victorops'
+      notify      Options for 'notify'
 
 
 To view all providers use the ``providers`` command like so:

--- a/source/conf.py
+++ b/source/conf.py
@@ -76,7 +76,7 @@ except ImportError:
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/source/providers/notify.rst
+++ b/source/providers/notify.rst
@@ -43,4 +43,4 @@ Full schema:
     - title
     - message
     - base_url
-type: object
+    type: object

--- a/source/providers/notify.rst
+++ b/source/providers/notify.rst
@@ -1,0 +1,46 @@
+Notify
+------
+
+Send notifications via `Notify <https://github.com/K0IN/Notify>`_
+
+.. code-block:: python
+
+    >>> from notifiers import get_notifier
+    >>> notify = get_notifier('notify')
+    >>> notify.required
+    {'required': ['title', 'message', 'base_url']}
+
+    >>> notify.notify(title='Hi!', message='my message', base_url='http://localhost:8787')
+    # some instances may need a token
+    >>> notify.notify(title='Hi!', message='my message', base_url='http://localhost:8787', token="send_key")
+
+Full schema:
+
+.. code-block:: yaml
+
+    additionalProperties: false
+    properties:
+      title:
+        title: Title of the message
+        type: string
+      message:
+        title: Body of the message
+        type: string
+      base_url:
+        title: URL of the Notify instance
+        type: string
+        description: |
+          The URL of the Notify instance. For example, if you are using the the demo instance you would use ``https://notify-demo.deno.dev``.
+      tags:
+        title: Tags to send the notification to
+        type: array
+        items:
+          type: string
+      token:
+        title: access token
+        type: string
+    required:
+    - title
+    - message
+    - base_url
+type: object

--- a/tests/providers/test_notify.py
+++ b/tests/providers/test_notify.py
@@ -1,5 +1,3 @@
-import pytest
-
 provider = "notify"
 
 

--- a/tests/providers/test_notify.py
+++ b/tests/providers/test_notify.py
@@ -4,7 +4,5 @@ provider = "notify"
 
 
 class TestNotify:
-    @pytest.mark.online
-    def test_sanity(self, provider, test_message):
-        data = {"message": test_message}
-        provider.notify(**data, raise_on_errors=True)
+    pass
+

--- a/tests/providers/test_notify.py
+++ b/tests/providers/test_notify.py
@@ -5,4 +5,3 @@ provider = "notify"
 
 class TestNotify:
     pass
-

--- a/tests/providers/test_notify.py
+++ b/tests/providers/test_notify.py
@@ -1,5 +1,23 @@
+import pytest
+
 provider = "notify"
 
 
 class TestNotify:
-    pass
+    """
+    Notify notifier tests
+    """
+
+    @pytest.mark.online
+    def test_notify_sanity(self, provider, test_message):
+        """Successful notify notification"""
+        data = {
+            "message": test_message,
+            "title": "test",
+            "base_url": "https://notify-demo.deno.dev",
+            "tags": ["test"],
+            "token": "mypassword",
+        }
+
+        rsp = provider.notify(**data)
+        rsp.raise_on_errors()

--- a/tests/providers/test_notify.py
+++ b/tests/providers/test_notify.py
@@ -1,0 +1,10 @@
+import pytest
+
+provider = "notify"
+
+
+class TestNotify:
+    @pytest.mark.online
+    def test_sanity(self, provider, test_message):
+        data = {"message": test_message}
+        provider.notify(**data, raise_on_errors=True)


### PR DESCRIPTION
PR for: https://github.com/liiight/notifiers/issues/465

Open [demo instance](https://notify-demo.deno.dev) and subscribe, then run the code:

```py
from notifiers import get_notifier
p = get_notifier('notify')
print(p.required)
res = p.notify(title='test', message='test', base_url='https://notify-demo.deno.dev', tags=['test'])
print(res)
```


a local test instance can be hosted like so (warning, hardcoded key):

> docker run -p 8787:8787 -e VAPID_KEY=eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwiYWxnIjoiRVMyNTYiLCJ4IjoiMGh4bURpNmRIWkJFQmx3MmZBOTVka09mNktSSHllc2NRb3JNV2dMNGR6TSIsInkiOiJCZnNYZ2tnMW9iWHMybmpmTWRyMmVDZ1FPZmFoVWE3WWtWczFuVzdfeWxVIiwiZCI6Ind4X3N5TmFkSFZ3OHhHOExVQzJhcWF2OG8zZVlQWEtVRmdEdDFDNm80b1UiLCJrZXlfb3BzIjpbInNpZ24iXSwiZXh0Ijp0cnVlfQ== -e SUB=mailto:admin@admin.com -e SENDKEY=mypassword ghcr.io/k0in/notify:latest

Where token must be set to "mypassword".

```py
from notifiers import get_notifier
p = get_notifier('notify')
print(p.required)
res = p.notify(title='test', message='test', base_url='http://localhost:8787', tags=['test'], token="mypassword")
print(res)
```
