### PR TITLE
feat: Add get providers from entry points

### DIFF
--- a/notifiers/core.py
+++ b/notifiers/core.py
@@ -4,6 +4,8 @@ import logging
 from abc import ABC
 from abc import abstractmethod
 from importlib.metadata import entry_points
+import importlib.machinery
+import importlib.util
 
 import jsonschema
 import requests
@@ -343,6 +345,29 @@ def get_notifier(provider_name: str, strict: bool = False) -> Provider:
     return None
 
 
+def load_provider_from_points(entry_points: str):
+    """Load a Provider class from a given entry point string.
+
+    This function takes an entry point string in the format
+    'module_path:class_name', imports the module dynamically using
+    importlib, and returns the specified class from the module.
+
+    :param entry_points: A string specifying the module path and class name, separated by a colon.
+    :return: :class:`Provider` or None
+    :raises ImportError: If the specified module cannot be imported.
+    :raises AttributeError: If the specified class cannot be found in the module.
+
+    Example:
+        >>> entry_points = "xxx.provider:Provider"
+        >>> plugin_class = load_provider_from_points(entry_points)
+        >>> plugin_instance = plugin_class()
+    """
+    instance_path, instance = entry_points.split(":")
+    module = importlib.import_module(instance_path)
+    provider = getattr(module, instance)
+    return provider
+
+
 def get_providers_from_entry_points(group_name: str = "notifiers") -> dict:
     """
     Get a dictionary of plugins from the entry points based on the given group name.
@@ -362,7 +387,7 @@ def get_providers_from_entry_points(group_name: str = "notifiers") -> dict:
     points = entry_points()
     for item in points.get(group_name, []):
         if item.group == group_name:
-            result[item.name] = item.value
+            result[item.name] = load_provider_from_points(item.value)
     return result
 
 

--- a/notifiers/core.py
+++ b/notifiers/core.py
@@ -11,13 +11,12 @@ import jsonschema
 import requests
 from jsonschema.exceptions import best_match
 
-from .exceptions import (
-    BadArguments,
-    NoSuchNotifierError,
-    NotificationError,
-    SchemaError,
-)
-from .utils.helpers import dict_from_environs, merge_dicts
+from .exceptions import BadArguments
+from .exceptions import NoSuchNotifierError
+from .exceptions import NotificationError
+from .exceptions import SchemaError
+from .utils.helpers import dict_from_environs
+from .utils.helpers import merge_dicts
 from .utils.schema.formats import format_checker
 
 DEFAULT_ENVIRON_PREFIX = "NOTIFIERS_"

--- a/source/api/core.rst
+++ b/source/api/core.rst
@@ -22,6 +22,10 @@ Core API reference
 
 .. autofunction:: notifiers.core.all_providers
 
+.. autofunction:: notifiers.core.get_all_providers
+
+.. autofunction:: notifiers.core.get_providers_from_entry_points
+
 .. autofunction:: notifiers.core.notify
 
 Logging

--- a/source/api/core.rst
+++ b/source/api/core.rst
@@ -24,6 +24,8 @@ Core API reference
 
 .. autofunction:: notifiers.core.get_all_providers
 
+.. autofunction:: notifiers.core.load_provider_from_points
+
 .. autofunction:: notifiers.core.get_providers_from_entry_points
 
 .. autofunction:: notifiers.core.notify

--- a/source/usage.rst
+++ b/source/usage.rst
@@ -207,3 +207,32 @@ You can also use the ``ok`` property:
     ['application token is invalid']
 
 
+Writing your own providers
+-----------------
+Making your provider installable by others
+If you want to make your provider externally available,
+you may define a so-called entry point for your distribution so that notifiers finds your provider module.
+Entry points are a feature that is provided by Documentation.
+notifiers looks up the `notifiers` entrypoint to discover its providers and you can thus make your provider available
+by defining it in your setuptools-invocation:
+
+.. code:: python
+
+    >>> # sample ./setup.py file
+    >>> from setuptools import setup
+
+    >>> setup(
+    >>>    name="myproject",
+    >>>    packages=["myproject"],
+    >>>    # the following makes a plugin available to notifiers
+    >>>    entry_points={"notifiers": ["name_of_provider = myproject.provider"]},
+    >>> )
+
+If a package is installed this way, `notifiers` will load `myproject.provider` as a provider for notifiers.
+
+.. code:: python
+
+    >>> from notifiers import get_notifier
+    >>> notifier = get_notifier('name_of_provider')
+    >>> notifier.notify(msgtype='text', api_key='1234', message='test')
+


### PR DESCRIPTION
This PR is add a new function to allow get providers from entry points.

```python
# setup.py
setup(
    name="notfiers_xxx_provider",
    package_dir={"": "."},
    packages=find_packages("."),
    entry_points={
        "notfiers": 
            ["provider1= notfiers_xxx_provider.Pushover2"],
            ["provider2= notfiers_xxx_provider.Pushover2"],
    },
)
```
