### PR TITLE
replace distutils for python 3.12

### DIFF
--- a/notifiers/utils/helpers.py
+++ b/notifiers/utils/helpers.py
@@ -2,8 +2,6 @@ import logging
 import os
 from pathlib import Path
 
-from distutils.util import strtobool
-
 log = logging.getLogger("notifiers")
 
 
@@ -14,7 +12,7 @@ def text_to_bool(value: str) -> bool:
     :param value: Value to check
     """
     try:
-        return bool(strtobool(value))
+        return value.lower() in {"y", "yes", "t", "true", "on", "1"}
     except (ValueError, AttributeError):
         return value is not None
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -76,7 +76,7 @@ except ImportError:
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Python 3.12 has removed `distutils`: https://docs.python.org/3.12/whatsnew/3.12.html#removed
