### PR TITLE
Use smtp_server_cls local variable

### DIFF
--- a/notifiers/providers/email.py
+++ b/notifiers/providers/email.py
@@ -161,8 +161,8 @@ class SMTP(Provider):
             )
 
     def _connect_to_server(self, data: dict):
-        self.smtp_server = smtplib.SMTP_SSL if data["ssl"] else smtplib.SMTP
-        self.smtp_server = self.smtp_server(data["host"], data["port"])
+        smtp_server_cls = smtplib.SMTP_SSL if data["ssl"] else smtplib.SMTP
+        self.smtp_server = smtp_server_cls(data["host"], data["port"])
         self.configuration = self._get_configuration(data)
         if data["tls"] and not data["ssl"]:
             self.smtp_server.ehlo()


### PR DESCRIPTION
If the initialization of `smtplib.SMTP` fails here (possibly transiently), further calls to [_send_notification](https://github.com/liiight/notifiers/blob/936c7d62724d342a853bebbd4ba9e1361c07d421/notifiers/providers/email.py#L178C9-L187) will not retry `_connect_to_server` as `self.smtp_server` will no longer be `NoneType`. This results in all subsequent email notifications getting [this error internal to smtplib](https://github.com/python/cpython/blob/5c16f699d22cba23d6d6c9438c3886889aa1a546/Lib/smtplib.py#L365)

this change is also related to issue https://github.com/liiight/notifiers/issues/439