### PR TITLE
fix(core): support entry points provider in get_notifier and add related test

### DIFF
--- a/notifiers/core.py
+++ b/notifiers/core.py
@@ -333,7 +333,7 @@ def get_notifier(provider_name: str, strict: bool = False) -> Provider:
     providers = get_all_providers()
     if provider_name in providers:
         log.debug("found a match for '%s', returning", provider_name)
-        return _all_providers[provider_name]()
+        return providers[provider_name]()
     if strict:
         raise NoSuchNotifierError(name=provider_name)
     return None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -89,6 +89,18 @@ class TestCore:
         assert p
         assert isinstance(p, Provider)
 
+    def test_get_notifier_entry_points(self, mock_provider, monkeypatch):
+        from notifiers import get_notifier
+
+        def fake_entry_points(_=None):
+            return {"dummy": type(mock_provider)}
+
+        monkeypatch.setattr("notifiers.core.get_providers_from_entry_points", fake_entry_points)
+
+        p = get_notifier("dummy")
+        assert p
+        assert isinstance(p, type(mock_provider))
+
     def test_all_providers(self, mock_provider, monkeypatch):
         """Test ``all_providers()`` helper function"""
 


### PR DESCRIPTION
This pull request makes a small but important fix to how notifier providers are retrieved and adds a new test to ensure correct behavior when using entry points.

Provider retrieval fix:

* Updated the `get_notifier` function in `notifiers/core.py` to use the dynamically fetched `providers` dictionary instead of a potentially stale global variable, ensuring the correct provider instance is returned.

Testing improvements:

* Added a new test `test_get_notifier_entry_points` in `tests/test_core.py` to verify that `get_notifier` correctly uses entry points for provider discovery, improving test coverage for dynamic provider loading.- Fix get_notifier logic to ensure providers from entry points are correctly retrieved.
- Add test_get_notifier_entry_points to mock and verify entry points provider support.

Why change _all_providers[provider_name]() to providers[provider_name]()?

Previously, get_notifier only looked up providers from the static _all_providers dictionary, which contains built-in providers. This approach did not support providers registered dynamically via Python entry points (i.e., plugin providers).

By switching to providers[provider_name](), where providers is the result of get_all_providers(), we ensure that both built-in and entry point (plugin) providers are included in the lookup. This makes the function extensible and compatible with third-party or dynamically registered providers, improving the flexibility and plugin support of the library.