### PR TITLE
Reconnect smtp_server instance if not connected

### DIFF
--- a/notifiers/providers/email.py
+++ b/notifiers/providers/email.py
@@ -179,7 +179,7 @@ class SMTP(Provider):
         errors = None
         try:
             configuration = self._get_configuration(data)
-            if not self.configuration or not self.smtp_server or self.configuration != configuration:
+            if not self.configuration or not self._is_smtp_connection_alive(self.smtp_server) or self.configuration != configuration:
                 self._connect_to_server(data)
             email = self._build_email(data)
             if data.get("attachments"):
@@ -193,3 +193,13 @@ class SMTP(Provider):
         ) as e:
             errors = [str(e)]
         return self.create_response(data, errors=errors)
+
+    @staticmethod
+    def _is_smtp_connection_alive(smtp_server: smtplib.SMTP):
+        if smtp_server is None:
+            return False
+        try:
+            status = smtp_server.noop()[0]
+            return status == 250
+        except Exception:
+            return False


### PR DESCRIPTION
the notifiers implementation of an email provider makes a connection to the mail server and reuses that as long as the further email payloads are meant to be sent through the same "configured" mail server connection. in python's source code for smtplib.py, they note that [the connection (of an SMTP instance) is kept open even if an exception is raised in sendmail](https://github.com/python/cpython/blob/7e1bac6a1aa6705c2386d80f093e575106de3340/Lib/smtplib.py#L851). However, this is not true in the case of a timeout communicating with the mail server (code 421), see source code [here](https://github.com/python/cpython/blob/7e1bac6a1aa6705c2386d80f093e575106de3340/Lib/smtplib.py#L883-L887). 
Given this, we were seeing issues in our application which uses notifiers library where we would get a timeout communicating with the mail server (which can happen for a variety of reasons) and then all of the following email requests would fail with with [this error](https://github.com/python/cpython/blob/7e1bac6a1aa6705c2386d80f093e575106de3340/Lib/smtplib.py#L372) because the connection was closed.
This PR makes it such that we check whether the connection is still alive before reusing it to send the email, else it tries to establish a new connection.