### PR TITLE
fix: coerce env var strings to schema-declared boolean/integer types

### DIFF
--- a/notifiers/core.py
+++ b/notifiers/core.py
@@ -11,7 +11,7 @@ from importlib_metadata import entry_points
 from jsonschema.exceptions import best_match
 
 from .exceptions import BadArguments, NoSuchNotifierError, NotificationError, SchemaError
-from .utils.helpers import dict_from_environs, merge_dicts
+from .utils.helpers import dict_from_environs, merge_dicts, text_to_bool
 from .utils.schema.formats import format_checker
 
 DEFAULT_ENVIRON_PREFIX = "NOTIFIERS_"
@@ -162,7 +162,37 @@ class SchemaResource(ABC):
         if not prefix:
             log.debug("using default environ prefix")
             prefix = DEFAULT_ENVIRON_PREFIX
-        return dict_from_environs(prefix, self.name, list(self.arguments.keys()))
+        environs = dict_from_environs(prefix, self.name, list(self.arguments.keys()))
+        return self._coerce_environs(environs)
+
+    def _coerce_environs(self, environs: dict) -> dict:
+        """
+        Coerces environment variable strings to the types declared in the provider schema.
+        Environment variables are always strings; this converts ``"true"``/``"1"`` to :class:`bool`
+        and numeric strings to :class:`int` or :class:`float` where the schema requires it.
+
+        :param environs: Raw environ dict (all values are strings)
+        :return: Environ dict with values cast to schema-declared types
+        """
+        properties = self.arguments
+        coerced = {}
+        for key, value in environs.items():
+            prop_type = properties.get(key, {}).get("type")
+            if prop_type == "boolean":
+                coerced[key] = text_to_bool(value)
+            elif prop_type == "integer":
+                try:
+                    coerced[key] = int(value)
+                except (ValueError, TypeError):
+                    coerced[key] = value
+            elif prop_type == "number":
+                try:
+                    coerced[key] = float(value)
+                except (ValueError, TypeError):
+                    coerced[key] = value
+            else:
+                coerced[key] = value
+        return coerced
 
     def _prepare_data(self, data: dict) -> dict:
         """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,7 +4,7 @@ import typing
 import pytest
 
 import notifiers
-from notifiers import notify
+from notifiers import get_notifier, notify
 from notifiers.core import SUCCESS_STATUS, Provider, Response
 from notifiers.exceptions import (
     BadArguments,
@@ -83,8 +83,6 @@ class TestCore:
 
     def test_get_notifier(self, mock_provider):
         """Test ``get_notifier()`` helper function"""
-        from notifiers import get_notifier
-
         p = get_notifier("mock_provider")
         assert p
         assert isinstance(p, Provider)
@@ -189,3 +187,19 @@ class TestCore:
     def test_direct_notify_negative(self):
         with pytest.raises(NoSuchNotifierError, match="No such notifier with name"):
             notify("foo", message="whateverz")
+
+    def test_environ_bool_and_int_coercion(self, monkeypatch):
+        """Env vars for boolean/integer schema fields must be coerced from string (issue #387)."""
+        p = get_notifier("email")
+
+        prefix = "COERCE_TEST_"
+        env_prefix = prefix + p.name + "_"
+        monkeypatch.setenv((env_prefix + "tls").upper(), "true")
+        monkeypatch.setenv((env_prefix + "ssl").upper(), "false")
+        monkeypatch.setenv((env_prefix + "port").upper(), "587")
+
+        environs = p._get_environs(prefix)
+        assert environs["tls"] is True, "'true' string must coerce to boolean True"
+        assert environs["ssl"] is False, "'false' string must coerce to boolean False"
+        assert environs["port"] == 587, "'587' string must coerce to integer 587"
+        assert isinstance(environs["port"], int)


### PR DESCRIPTION
## Problem

Environment variables are always strings, but provider schemas declare fields with `"type": "boolean"` or `"type": "integer"`. When these settings are supplied through environment variables (e.g. `NOTIFIERS_EMAIL_TLS=true`), they are passed as raw strings to jsonschema validation, which raises `BadArguments`:

```
notifiers.exceptions.BadArguments: Error with sent data: 'true' is not of type 'boolean'
```

This has been reported in issue #387 (open since 2020).

## Fix

Add `_coerce_environs()` to `SchemaResource`, called at the end of `_get_environs()`. It inspects each returned key against the provider's JSON schema and casts:

- `"boolean"` → uses the existing `text_to_bool()` helper (`"true"` / `"1"` / `"yes"` / `"on"` → `True`, etc.)
- `"integer"` → `int()`
- `"number"` → `float()`
- Everything else → unchanged string

The fix is ~30 lines, all pure Python, and places the responsibility where the schema context is already available.

## Before / After

```python
# Before — BadArguments raised
import os, notifiers
os.environ["NOTIFIERS_EMAIL_TLS"] = "true"
notifiers.get_notifier("email").notify(message="hi", ...)
# notifiers.exceptions.BadArguments: 'true' is not of type 'boolean'

# After — works correctly
result = notifiers.get_notifier("email")._get_environs("NOTIFIERS_")
assert result["tls"] is True
assert result["port"] == 587  # integer coercion also works
```

## Tests

A new `test_environ_bool_and_int_coercion` test in `tests/test_core.py` covers `"true"` → `True`, `"false"` → `False`, and `"587"` → `587`. All 34 tests pass.

---

This pull request was prepared with the assistance of AI, under my direction and review.